### PR TITLE
Fix a compilation warning under windows

### DIFF
--- a/regint.h
+++ b/regint.h
@@ -789,7 +789,12 @@ extern int  onig_is_code_in_cc_len P_((int enclen, OnigCodePoint code, CClassNod
 
 /* strend hash */
 typedef void hash_table_type;
+#ifdef _WIN32
+# include <windows.h>
+typedef ULONG_PTR hash_data_type;
+#else
 typedef unsigned long hash_data_type;
+#endif
 
 extern hash_table_type* onig_st_init_strend_table_with_size P_((int size));
 extern int onig_st_lookup_strend P_((hash_table_type* table, const UChar* str_key, const UChar* end_key, hash_data_type *value));


### PR DESCRIPTION
Fixes following compilationg warning related to https://github.com/kkos/oniguruma/commit/b0734c30a5d973776fe7fd93e611f3a93652c41a

`warning C4133: 'function' : incompatible types - from 'hash_data_type *' to 'st_data_t *'`