### PR TITLE
Fix UTF-16/32 problems

### DIFF
--- a/src/regcomp.c
+++ b/src/regcomp.c
@@ -2231,6 +2231,7 @@ is_not_included(Node* x, Node* y, regex_t* reg)
             return 0;
           }
           else {
+            if (IS_NOT_NULL(xc->mbuf)) return 0;
             for (i = 0; i < SINGLE_BYTE_SIZE; i++) {
               if (! IS_CODE_SB_WORD(reg->enc, i)) {
                 if (!IS_NCCLASS_NOT(xc)) {

--- a/src/regerror.c
+++ b/src/regerror.c
@@ -348,21 +348,12 @@ onig_snprintf_with_pattern(buf, bufsize, enc, pat, pat_end, fmt, va_alist)
 
     p = pat;
     while (p < pat_end) {
-      if (*p == '\\') {
-	*s++ = *p++;
-	len = enclen(enc, p);
-	while (len-- > 0) *s++ = *p++;
-      }
-      else if (*p == '/') {
-	*s++ = (unsigned char )'\\';
-	*s++ = *p++;
-      }
-      else if (ONIGENC_IS_MBC_HEAD(enc, p)) {
+      if (ONIGENC_IS_MBC_HEAD(enc, p)) {
         len = enclen(enc, p);
         if (ONIGENC_MBC_MINLEN(enc) == 1) {
           while (len-- > 0) *s++ = *p++;
         }
-        else { /* for UTF16 */
+        else { /* for UTF16/32 */
           int blen;
 
           while (len-- > 0) {
@@ -372,6 +363,15 @@ onig_snprintf_with_pattern(buf, bufsize, enc, pat, pat_end, fmt, va_alist)
             while (blen-- > 0) *s++ = *bp++;
           }
         }
+      }
+      else if (*p == '\\') {
+	*s++ = *p++;
+	len = enclen(enc, p);
+	while (len-- > 0) *s++ = *p++;
+      }
+      else if (*p == '/') {
+	*s++ = (unsigned char )'\\';
+	*s++ = *p++;
       }
       else if (!ONIGENC_IS_CODE_PRINT(enc, *p) &&
 	       !ONIGENC_IS_CODE_SPACE(enc, *p)) {

--- a/src/regparse.c
+++ b/src/regparse.c
@@ -1639,9 +1639,10 @@ add_code_range_to_buf(BBuf** pbuf, OnigCodePoint from, OnigCodePoint to)
       bound = x;
   }
 
-  for (high = low, bound = n; high < bound; ) {
+  high = (to == ~((OnigCodePoint )0)) ? n : low;
+  for (bound = n; high < bound; ) {
     x = (high + bound) >> 1;
-    if (to >= data[x*2] - 1)
+    if (to + 1 >= data[x*2])
       high = x + 1;
     else
       bound = x;


### PR DESCRIPTION
Imported three patches for UTF-16/32 from Onigmo.

* `/[\x{0}-X]/i` doesn't match properly when UTF-16/32 is used.
* `/[a-c#]+\W/ =~ "def#"` fails when encoding is UTF-16/32
* When encoding is UTF-16LE/32LE, warning message with '/' or '\\' are not shown properly.

#36 might be fixed by them.