### PR TITLE
Deeply nested capture groups cause stack overflow

### DIFF
--- a/doc/API
+++ b/doc/API
@@ -629,6 +629,20 @@ Oniguruma API  Version 6.1.0  2016/08/22
   normal return: ONIG_NORMAL
 
 
+# unsigned int onig_get_parse_depth_limit(void)
+
+  Return the maximum depth of parser recursion.
+  (default: DEFAULT_PARSE_DEPTH_LIMIT defined in regint.h. Currently 4096.)
+
+
+# int onig_set_parse_depth_limit(unsigned int depth)
+
+  Set the maximum depth of parser recursion.
+  (depth = 0: Set to the default value defined in regint.h.)
+
+  normal return: ONIG_NORMAL
+
+
 # int onig_end(void)
 
   The use of this library is finished.

--- a/doc/API.ja
+++ b/doc/API.ja
@@ -636,6 +636,20 @@
   正常終了戻り値: ONIG_NORMAL
 
 
+# unsigned int onig_get_parse_depth_limit(void)
+
+  再帰パース処理の最大深さを返す。
+  (デフォルト: regint.h で定義されている DEFAULT_PARSE_DEPTH_LIMIT。現在は 4096)
+
+
+# int onig_set_parse_depth_limit(unsigned int depth)
+
+  再帰パース処理の最大深さを指定する。
+  (depth = 0: regint.h で定義されたデフォルト値に設定する。)
+
+  正常終了戻り値: ONIG_NORMAL
+
+
 # int onig_end(void)
 
   ライブラリの使用を終了する。

--- a/src/oniguruma.h
+++ b/src/oniguruma.h
@@ -543,6 +543,7 @@ ONIG_EXTERN OnigSyntaxType*   OnigDefaultSyntax;
 #define ONIGERR_UNDEFINED_BYTECODE                            -13
 #define ONIGERR_UNEXPECTED_BYTECODE                           -14
 #define ONIGERR_MATCH_STACK_LIMIT_OVER                        -15
+#define ONIGERR_PARSE_DEPTH_LIMIT_OVER                        -16
 #define ONIGERR_DEFAULT_ENCODING_IS_NOT_SETTED                -21
 #define ONIGERR_SPECIFIED_ENCODING_CANT_CONVERT_TO_WIDE_CHAR  -22
 #define ONIGERR_FAIL_TO_INITIALIZE                            -23
@@ -820,6 +821,10 @@ ONIG_EXTERN
 unsigned int onig_get_match_stack_limit_size P_((void));
 ONIG_EXTERN
 int onig_set_match_stack_limit_size P_((unsigned int size));
+ONIG_EXTERN
+unsigned int onig_get_parse_depth_limit P_((void));
+ONIG_EXTERN
+int onig_set_parse_depth_limit P_((unsigned int depth));
 ONIG_EXTERN
 int onig_unicode_define_user_property P_((const char* name, OnigCodePoint* ranges));
 ONIG_EXTERN

--- a/src/regerror.c
+++ b/src/regerror.c
@@ -54,6 +54,8 @@ onig_error_code_to_format(int code)
     p = "fail to memory allocation"; break;
   case ONIGERR_MATCH_STACK_LIMIT_OVER:
     p = "match-stack limit over"; break;
+  case ONIGERR_PARSE_DEPTH_LIMIT_OVER:
+    p = "parse depth limit over"; break;
   case ONIGERR_TYPE_BUG:
     p = "undefined type (bug)"; break;
   case ONIGERR_PARSER_BUG:

--- a/src/regint.h
+++ b/src/regint.h
@@ -71,6 +71,7 @@
 
 #define INIT_MATCH_STACK_SIZE                     160
 #define DEFAULT_MATCH_STACK_LIMIT_SIZE              0 /* unlimited */
+#define DEFAULT_PARSE_DEPTH_LIMIT                4096
 
 #if defined(__GNUC__)
 #  define ARG_UNUSED  __attribute__ ((unused))

--- a/src/regparse.h
+++ b/src/regparse.h
@@ -306,6 +306,7 @@ typedef struct {
   int curr_max_regnum;
   int has_recursion;
 #endif
+  unsigned int parse_depth;
 } ScanEnv;
 
 


### PR DESCRIPTION
Oniguruma's parser uses recursion, so it causes stack overflow when parsing
deeply nested capture groups. E.g.:

  x2("(" * 32767 + "a" + ")" * 32767, "a", 0, 1)

This patch sets a limit for this.
The default value is defined in regint.h:
* DEFAULT_PARSE_DEPTH_LIMIT (Currently 4096)

Also add two APIs to support this:
* onig_get_parse_depth_limit
* onig_set_parse_depth_limit

Ported from k-takata/Onigmo#68 .