### PR TITLE
Fix .* optimization

### DIFF
--- a/src/regcomp.c
+++ b/src/regcomp.c
@@ -4160,6 +4160,9 @@ concat_opt_anc_info(OptAncInfo* to, OptAncInfo* left, OptAncInfo* right,
   if (right_len == 0) {
     to->right_anchor |= left->right_anchor;
   }
+  else {
+    to->right_anchor |= (left->right_anchor & ANCHOR_PREC_READ_NOT);
+  }
 }
 
 static int
@@ -5003,12 +5006,14 @@ set_optimize_info_from_tree(Node* node, regex_t* reg, ScanEnv* scan_env)
   if (r) return r;
 
   reg->anchor = opt.anc.left_anchor & (ANCHOR_BEGIN_BUF |
-        ANCHOR_BEGIN_POSITION | ANCHOR_ANYCHAR_STAR | ANCHOR_ANYCHAR_STAR_ML);
+        ANCHOR_BEGIN_POSITION | ANCHOR_ANYCHAR_STAR | ANCHOR_ANYCHAR_STAR_ML |
+        ANCHOR_LOOK_BEHIND);
 
   if ((opt.anc.left_anchor & (ANCHOR_LOOK_BEHIND | ANCHOR_PREC_READ_NOT)) != 0)
     reg->anchor &= ~ANCHOR_ANYCHAR_STAR_ML;
 
-  reg->anchor |= opt.anc.right_anchor & (ANCHOR_END_BUF | ANCHOR_SEMI_END_BUF);
+  reg->anchor |= opt.anc.right_anchor & (ANCHOR_END_BUF | ANCHOR_SEMI_END_BUF |
+       ANCHOR_PREC_READ_NOT);
 
   if (reg->anchor & (ANCHOR_END_BUF | ANCHOR_SEMI_END_BUF)) {
     reg->anchor_dmin = opt.len.min;

--- a/src/regexec.c
+++ b/src/regexec.c
@@ -3626,9 +3626,11 @@ onig_search(regex_t* reg, const UChar* str, const UChar* end,
             prev = s;
             s += enclen(reg->enc, s);
 
-            while (!ONIGENC_IS_MBC_NEWLINE(reg->enc, prev, end) && s < range) {
-              prev = s;
-              s += enclen(reg->enc, s);
+            if ((reg->anchor & (ANCHOR_LOOK_BEHIND | ANCHOR_PREC_READ_NOT)) == 0) {
+              while (!ONIGENC_IS_MBC_NEWLINE(reg->enc, prev, end) && s < range) {
+                prev = s;
+                s += enclen(reg->enc, s);
+              }
             }
           } while (s < range);
           goto mismatch;


### PR DESCRIPTION
Fix following patterns:
* `/(?<=a).*b/ =~ 'aab'`
* `/(?!a).*b/ =~ 'ab'`

Ported from Onigmo. (k-takata/Onigmo#44)