### PR TITLE
fix problem with optimization of \z

### DIFF
--- a/src/regexec.c
+++ b/src/regexec.c
@@ -3493,15 +3493,14 @@ onig_search(regex_t* reg, const UChar* str, const UChar* end,
           start = min_semi_end - reg->anchor_dmax;
           if (start < end)
             start = onigenc_get_right_adjust_char_head(reg->enc, str, start);
-          else { /* match with empty at end */
-            start = onigenc_get_prev_char_head(reg->enc, str, end);
-          }
         }
         if ((OnigLen )(max_semi_end - (range - 1)) < reg->anchor_dmin) {
           range = max_semi_end - reg->anchor_dmin + 1;
         }
 
-        if (start >= range) goto mismatch_no_msa;
+        if (start > range) goto mismatch_no_msa;
+        /* If start == range, match with empty at end.
+           Backward search is used. */
       }
       else {
         if ((OnigLen )(min_semi_end - range) > reg->anchor_dmax) {


### PR DESCRIPTION
`"こんにちは" =~ /\n?\z/` didn't match.

see:
  http://bugs.ruby-lang.org/issues/8210
  http://stackoverflow.com/a/15885857/925913

Ported from k-takata/Onigmo#16 .