### PR TITLE
[0-9-a] was not allowed as [0-9\-a]

### DIFF
--- a/src/regparse.c
+++ b/src/regparse.c
@@ -4340,7 +4340,7 @@ parse_char_class(Node** np, OnigToken* tok, UChar** src, UChar* end,
 	
         if (IS_SYNTAX_BV(env->syntax, ONIG_SYN_ALLOW_DOUBLE_RANGE_OP_IN_CC)) {
           CC_ESC_WARN(env, (UChar* )"-");
-          goto any_char_in;   /* [0-9-a] is allowed as [0-9\-a] */
+          goto range_end_val;   /* [0-9-a] is allowed as [0-9\-a] */
         }
         r = ONIGERR_UNMATCHED_RANGE_SPECIFIER_IN_CHAR_CLASS;
         goto err;


### PR DESCRIPTION
It did not work as the comment said.
This was originally fixed by Ruby r37175.