### PR TITLE
Correct spelling and grammar in FAQ (English)

### DIFF
--- a/doc/FAQ
+++ b/doc/FAQ
@@ -1,12 +1,12 @@
 FAQ    2006/11/14
 
-1. Lognest match
+1. Longest match
 
-   You can execute longest match by using ONIG_OPTION_FIND_LONGEST option
+   You can execute the longest match by using ONIG_OPTION_FIND_LONGEST option
    in onig_new().
 
 2. Mailing list
 
-   There is no mailing list about Oniguruma.
+   There is no mailing list for Oniguruma.
 
 // END


### PR DESCRIPTION
- Correct "lognest" => "longest"
- Add the article "the" to "execute longest match"
- Change "mailing list about Oniguruma" to "mailing list for Oniguruma" in the interest of more natural English