### PR TITLE
Out of tree windows builds

### DIFF
--- a/make_win32.bat
+++ b/make_win32.bat
@@ -2,4 +2,4 @@ SET ONIG_DIR=%~dp0\src
 set THIS_DIR=%~dp0
 set BUILD_DIR=%cd%
 copy %ONIG_DIR%\config.h.win32 %BUILD_DIR%\config.h
-nmake -f %THIS_DIR%\Makefile.windows
+nmake -f %ONIG_DIR%\Makefile.windows

--- a/make_win32.bat
+++ b/make_win32.bat
@@ -1,3 +1,5 @@
-cd src
-copy config.h.win32 config.h
-nmake -f Makefile.windows
+SET ONIG_DIR=%~dp0\src
+set THIS_DIR=%~dp0
+set BUILD_DIR=%cd%
+copy %ONIG_DIR%\config.h.win32 %BUILD_DIR%\config.h
+nmake -f %THIS_DIR%\Makefile.windows

--- a/make_win64.bat
+++ b/make_win64.bat
@@ -2,4 +2,4 @@ SET ONIG_DIR=%~dp0\src
 set THIS_DIR=%~dp0
 set BUILD_DIR=%cd%
 copy %ONIG_DIR%\config.h.win64 %BUILD_DIR%\config.h
-nmake -f %THIS_DIR%\Makefile.windows
+nmake -f %ONIG_DIR%\Makefile.windows

--- a/make_win64.bat
+++ b/make_win64.bat
@@ -1,3 +1,5 @@
-cd src
-copy config.h.win64 config.h
-nmake -f Makefile.windows
+SET ONIG_DIR=%~dp0\src
+set THIS_DIR=%~dp0
+set BUILD_DIR=%cd%
+copy %ONIG_DIR%\config.h.win64 %BUILD_DIR%\config.h
+nmake -f %THIS_DIR%\Makefile.windows

--- a/src/Makefile.windows
+++ b/src/Makefile.windows
@@ -25,42 +25,42 @@ libname   = $(libbase)_s.lib
 dllname   = $(libbase).dll
 dlllib    = $(libbase).lib
 
-onigheaders  = oniguruma.h regint.h regparse.h regenc.h st.h
-posixheaders = onigposix.h
+onigheaders  = $(ONIG_DIR)/oniguruma.h $(ONIG_DIR)/regint.h $(ONIG_DIR)/regparse.h $(ONIG_DIR)/regenc.h $(ONIG_DIR)/st.h
+posixheaders = $(ONIG_DIR)/onigposix.h
 headers      = $(posixheaders) $(onigheaders)
 
-onigobjs     = reggnu.obj regerror.obj regparse.obj regext.obj regcomp.obj \
-	       regexec.obj regenc.obj regsyntax.obj regtrav.obj \
-	       regversion.obj st.obj onig_init.obj
-posixobjs    = regposix.obj regposerr.obj
+onigobjs     = $(BUILD_DIR)/reggnu.obj $(BUILD_DIR)/regerror.obj $(BUILD_DIR)/regparse.obj $(BUILD_DIR)/regext.obj $(BUILD_DIR)/regcomp.obj \
+	       $(BUILD_DIR)/regexec.obj $(BUILD_DIR)/regenc.obj $(BUILD_DIR)/regsyntax.obj $(BUILD_DIR)/regtrav.obj \
+	       $(BUILD_DIR)/regversion.obj $(BUILD_DIR)/st.obj $(BUILD_DIR)/onig_init.obj
+posixobjs    = $(BUILD_DIR)/regposix.obj $(BUILD_DIR)/regposerr.obj
 libobjs      = $(onigobjs) $(posixobjs)
 
-jp_objs      =  euc_jp.obj sjis.obj
-iso8859_objs =  iso8859_1.obj  iso8859_2.obj \
-		iso8859_3.obj  iso8859_4.obj \
-		iso8859_5.obj  iso8859_6.obj \
-		iso8859_7.obj  iso8859_8.obj \
-		iso8859_9.obj  iso8859_10.obj \
-		iso8859_11.obj iso8859_13.obj \
-		iso8859_14.obj iso8859_15.obj \
-		iso8859_16.obj
+jp_objs      =  $(BUILD_DIR)/euc_jp.obj $(BUILD_DIR)/sjis.obj
+iso8859_objs =  $(BUILD_DIR)/iso8859_1.obj  $(BUILD_DIR)/iso8859_2.obj \
+		$(BUILD_DIR)/iso8859_3.obj  $(BUILD_DIR)/iso8859_4.obj \
+		$(BUILD_DIR)/iso8859_5.obj  $(BUILD_DIR)/iso8859_6.obj \
+		$(BUILD_DIR)/iso8859_7.obj  $(BUILD_DIR)/iso8859_8.obj \
+		$(BUILD_DIR)/iso8859_9.obj  $(BUILD_DIR)/iso8859_10.obj \
+		$(BUILD_DIR)/iso8859_11.obj $(BUILD_DIR)/iso8859_13.obj \
+		$(BUILD_DIR)/iso8859_14.obj $(BUILD_DIR)/iso8859_15.obj \
+		$(BUILD_DIR)/iso8859_16.obj
 
-encobjs = ascii.obj utf8.obj \
-		unicode.obj \
-		utf16_be.obj utf16_le.obj \
-		utf32_be.obj utf32_le.obj \
+encobjs = $(BUILD_DIR)/ascii.obj $(BUILD_DIR)/utf8.obj \
+		$(BUILD_DIR)/unicode.obj \
+		$(BUILD_DIR)/utf16_be.obj $(BUILD_DIR)/utf16_le.obj \
+		$(BUILD_DIR)/utf32_be.obj $(BUILD_DIR)/utf32_le.obj \
 		$(jp_objs) $(iso8859_objs) \
-		euc_tw.obj euc_kr.obj big5.obj \
-		gb18030.obj \
-		koi8_r.obj  \
-		cp1251.obj \
-		euc_jp_prop.obj sjis_prop.obj \
-		unicode_unfold_key.obj unicode_fold1_key.obj \
-		unicode_fold2_key.obj unicode_fold3_key.obj	# koi8.obj
+		$(BUILD_DIR)/euc_tw.obj $(BUILD_DIR)/euc_kr.obj $(BUILD_DIR)/big5.obj \
+		$(BUILD_DIR)/gb18030.obj \
+		$(BUILD_DIR)/koi8_r.obj  \
+		$(BUILD_DIR)/cp1251.obj \
+		$(BUILD_DIR)/euc_jp_prop.obj $(BUILD_DIR)/sjis_prop.obj \
+		$(BUILD_DIR)/unicode_unfold_key.obj $(BUILD_DIR)/unicode_fold1_key.obj \
+		$(BUILD_DIR)/unicode_fold2_key.obj $(BUILD_DIR)/unicode_fold3_key.obj	# $(BUILD_DIR)/koi8.obj
 
-onigsources  = regerror.c regparse.c regext.c regcomp.c regexec.c regenc.c \
-	       regsyntax.c regtrav.c regversion.c reggnu.c st.c
-posixsources = regposix.c regposerr.c
+onigsources  = $(ONIG_DIR)/regerror.c $(ONIG_DIR)/regparse.c $(ONIG_DIR)/regext.c $(ONIG_DIR)/regcomp.c $(ONIG_DIR)/regexec.c $(ONIG_DIR)/regenc.c \
+	       $(ONIG_DIR)/regsyntax.c $(ONIG_DIR)/regtrav.c $(ONIG_DIR)/regversion.c $(ONIG_DIR)/reggnu.c $(ONIG_DIR)/st.c
+posixsources = $(ONIG_DIR)/regposix.c $(ONIG_DIR)/regposerr.c
 libsources   = $(posixsources) $(onigsources)
 rubysources  = $(onigsources)
 
@@ -77,7 +77,7 @@ makeargs = $(MFLAGS) CPPFLAGS='$(CPPFLAGS)' CFLAGS='$(CFLAGS)' CC='$(CC)'
 .SUFFIXES:
 .SUFFIXES: .obj .c .h .ps .dvi .info .texinfo
 
-.c.obj:
+{$(ONIG_DIR)}.c{$(BUILD_DIR)}.obj:
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(DEFS) /I. /I.. /Fo$@ /c $<
 
 # targets
@@ -96,58 +96,58 @@ $(libname): $(libobjs) $(encobjs)
 $(dllname): $(libobjs) $(encobjs)
 	$(ARDLL) $(libobjs) $(encobjs) -Fe$@ $(ARDLL_FLAGS)
 
-regparse.obj:  regparse.c $(onigheaders) config.h st.h
-regext.obj:    regext.c   $(onigheaders) config.h
-regtrav.obj:   regtrav.c  $(onigheaders) config.h
-regcomp.obj:   regcomp.c  $(onigheaders) config.h
-regexec.obj:   regexec.c  regint.h regenc.h oniguruma.h config.h
-reggnu.obj:    reggnu.c   regint.h regenc.h oniguruma.h config.h oniggnu.h
-regerror.obj:  regerror.c regint.h regenc.h oniguruma.h config.h
-regenc.obj:    regenc.c   regenc.h oniguruma.h config.h
-regsyntax.obj: regsyntax.c regint.h regenc.h oniguruma.h config.h
-regversion.obj: regversion.c oniguruma.h config.h
-regposix.obj:  regposix.c $(posixheaders) oniguruma.h config.h
-regposerr.obj: regposerr.c $(posixheaders) config.h
-st.obj:        st.c regint.h oniguruma.h config.h st.h
-onig_init.obj: onig_init.c oniguruma.h
+$(BUILD_DIR)/regparse.obj:  $(ONIG_DIR)/regparse.c $(onigheaders) $(BUILD_DIR)/config.h
+$(BUILD_DIR)/regext.obj:    $(ONIG_DIR)/regext.c   $(onigheaders) $(BUILD_DIR)/config.h
+$(BUILD_DIR)/regtrav.obj:   $(ONIG_DIR)/regtrav.c  $(onigheaders) $(BUILD_DIR)/config.h
+$(BUILD_DIR)/regcomp.obj:   $(ONIG_DIR)/regcomp.c  $(onigheaders) $(BUILD_DIR)/config.h
+$(BUILD_DIR)/regexec.obj:   $(ONIG_DIR)/regexec.c  $(ONIG_DIR)/regint.h $(ONIG_DIR)/regenc.h $(ONIG_DIR)/oniguruma.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/reggnu.obj:    $(ONIG_DIR)/reggnu.c   $(ONIG_DIR)/regint.h $(ONIG_DIR)/regenc.h $(ONIG_DIR)/oniguruma.h $(BUILD_DIR)/config.h $(ONIG_DIR)/oniggnu.h
+$(BUILD_DIR)/regerror.obj:  $(ONIG_DIR)/regerror.c $(ONIG_DIR)/regint.h $(ONIG_DIR)/regenc.h $(ONIG_DIR)/oniguruma.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/regenc.obj:    $(ONIG_DIR)/regenc.c   $(ONIG_DIR)/regenc.h $(ONIG_DIR)/oniguruma.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/regsyntax.obj: $(ONIG_DIR)/regsyntax.c $(ONIG_DIR)/regint.h $(ONIG_DIR)/regenc.h $(ONIG_DIR)/oniguruma.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/regversion.obj: $(ONIG_DIR)/regversion.c $(ONIG_DIR)/oniguruma.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/regposix.obj:  $(ONIG_DIR)/regposix.c $(posixheaders) $(ONIG_DIR)/oniguruma.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/regposerr.obj: $(ONIG_DIR)/regposerr.c $(posixheaders) $(BUILD_DIR)/config.h
+$(BUILD_DIR)/st.obj:        $(ONIG_DIR)/st.c $(ONIG_DIR)/regint.h $(ONIG_DIR)/oniguruma.h $(BUILD_DIR)/config.h $(ONIG_DIR)/st.h
+$(BUILD_DIR)/onig_init.obj: $(ONIG_DIR)/onig_init.c $(ONIG_DIR)/oniguruma.h
 
-ascii.obj:      ascii.c regenc.h config.h
-unicode.obj:    unicode.c unicode_fold_data.c unicode_property_data.c regenc.h config.h
-utf8.obj:       utf8.c regenc.h config.h
-utf16_be.obj:   utf16_be.c regenc.h config.h
-utf16_le.obj:   utf16_le.c regenc.h config.h
-utf32_be.obj:   utf32_be.c regenc.h config.h
-utf32_le.obj:   utf32_le.c regenc.h config.h
-euc_jp.obj:     euc_jp.c regenc.h config.h
-euc_tw.obj:     euc_tw.c regenc.h config.h
-euc_kr.obj:     euc_kr.c regenc.h config.h
-sjis.obj:       sjis.c regenc.h config.h
-iso8859_1.obj:  iso8859_1.c regenc.h config.h
-iso8859_2.obj:  iso8859_2.c regenc.h config.h
-iso8859_3.obj:  iso8859_3.c regenc.h config.h
-iso8859_4.obj:  iso8859_4.c regenc.h config.h
-iso8859_5.obj:  iso8859_5.c regenc.h config.h
-iso8859_6.obj:  iso8859_6.c regenc.h config.h
-iso8859_7.obj:  iso8859_7.c regenc.h config.h
-iso8859_8.obj:  iso8859_8.c regenc.h config.h
-iso8859_9.obj:  iso8859_9.c regenc.h config.h
-iso8859_10.obj: iso8859_10.c regenc.h config.h
-iso8859_11.obj: iso8859_11.c regenc.h config.h
-iso8859_13.obj: iso8859_13.c regenc.h config.h
-iso8859_14.obj: iso8859_14.c regenc.h config.h
-iso8859_15.obj: iso8859_15.c regenc.h config.h
-iso8859_16.obj: iso8859_16.c regenc.h config.h
-koi8.obj:       koi8.c   regenc.h config.h
-koi8_r.obj:     koi8_r.c regenc.h config.h
-cp1251.obj:     cp1251.c regenc.h config.h
-big5.obj:       big5.c   regenc.h config.h
-gb18030.obj:    gb18030.c regenc.h config.h
-euc_jp_prop.obj:  euc_jp_prop.c regenc.h
-sjis_prop.obj:    sjis_prop.c regenc.h
-unicode_unfold_key.obj: unicode_unfold_key.c regenc.h config.h
-unicode_fold1_key.obj: unicode_fold1_key.c regenc.h config.h
-unicode_fold2_key.obj: unicode_fold2_key.c regenc.h config.h
-unicode_fold3_key.obj: unicode_fold3_key.c regenc.h config.h
+$(BUILD_DIR)/ascii.obj:      $(ONIG_DIR)/ascii.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/unicode.obj:    $(ONIG_DIR)/unicode.c $(ONIG_DIR)/unicode_fold_data.c $(ONIG_DIR)/unicode_property_data.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/utf8.obj:       $(ONIG_DIR)/utf8.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/utf16_be.obj:   $(ONIG_DIR)/utf16_be.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/utf16_le.obj:   $(ONIG_DIR)/utf16_le.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/utf32_be.obj:   $(ONIG_DIR)/utf32_be.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/utf32_le.obj:   $(ONIG_DIR)/utf32_le.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/euc_jp.obj:     $(ONIG_DIR)/euc_jp.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/euc_tw.obj:     $(ONIG_DIR)/euc_tw.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/euc_kr.obj:     $(ONIG_DIR)/euc_kr.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/sjis.obj:       $(ONIG_DIR)/sjis.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/iso8859_1.obj:  $(ONIG_DIR)/iso8859_1.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/iso8859_2.obj:  $(ONIG_DIR)/iso8859_2.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/iso8859_3.obj:  $(ONIG_DIR)/iso8859_3.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/iso8859_4.obj:  $(ONIG_DIR)/iso8859_4.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/iso8859_5.obj:  $(ONIG_DIR)/iso8859_5.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/iso8859_6.obj:  $(ONIG_DIR)/iso8859_6.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/iso8859_7.obj:  $(ONIG_DIR)/iso8859_7.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/iso8859_8.obj:  $(ONIG_DIR)/iso8859_8.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/iso8859_9.obj:  $(ONIG_DIR)/iso8859_9.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/iso8859_10.obj: $(ONIG_DIR)/iso8859_10.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/iso8859_11.obj: $(ONIG_DIR)/iso8859_11.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/iso8859_13.obj: $(ONIG_DIR)/iso8859_13.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/iso8859_14.obj: $(ONIG_DIR)/iso8859_14.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/iso8859_15.obj: $(ONIG_DIR)/iso8859_15.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/iso8859_16.obj: $(ONIG_DIR)/iso8859_16.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/koi8.obj:       $(ONIG_DIR)/koi8.c   $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/koi8_r.obj:     $(ONIG_DIR)/koi8_r.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/cp1251.obj:     $(ONIG_DIR)/cp1251.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/big5.obj:       $(ONIG_DIR)/big5.c   $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/gb18030.obj:    $(ONIG_DIR)/gb18030.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/euc_jp_prop.obj:  $(ONIG_DIR)/euc_jp_prop.c $(ONIG_DIR)/regenc.h
+$(BUILD_DIR)/sjis_prop.obj:    $(ONIG_DIR)/sjis_prop.c $(ONIG_DIR)/regenc.h
+$(BUILD_DIR)/unicode_unfold_key.obj: $(ONIG_DIR)/unicode_unfold_key.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/unicode_fold1_key.obj: $(ONIG_DIR)/unicode_fold1_key.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/unicode_fold2_key.obj: $(ONIG_DIR)/unicode_fold2_key.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
+$(BUILD_DIR)/unicode_fold3_key.obj: $(ONIG_DIR)/unicode_fold3_key.c $(ONIG_DIR)/regenc.h $(BUILD_DIR)/config.h
 
 # C library test
 ctest: $(testc)
@@ -158,26 +158,26 @@ ptest: $(testp)
 	.\$(testp)
 
 $(testc): $(testc).c $(libname)
-	$(CC) -nologo /Fe:$(testc) -DONIG_EXTERN=extern $(testc).c $(libname)
+	$(CC) -nologo -o $(testc) -DONIG_EXTERN=extern $(testc).c $(libname)
 
 $(testp): $(testc).c $(dlllib)
-	$(CC) -nologo -DPOSIX_TEST /Fe:$(testp) $(testc).c $(dlllib)
+	$(CC) -nologo -DPOSIX_TEST -o $(testp) $(testc).c $(dlllib)
 
 #$(testc)u.c: test.rb testconvu.rb
 #	ruby -Ke testconvu.rb test.rb > $@
 
 $(testc)u: $(testc)u.c $(libname)
-	$(CC) -nologo /Fe:$(testc)u -DONIG_EXTERN=extern $(testc)u.c $(libname)
+	$(CC) -nologo -o $(testc)u -DONIG_EXTERN=extern $(testc)u.c $(libname)
 
 clean:
-	del *.obj *.lib *.exp *.dll $(testp).exe $(testc).exe $(testc).obj
+	del $(BUILD_DIR)/*.obj $(BUILD_DIR)/*.lib $(BUILD_DIR)/*.exp $(BUILD_DIR)/*.dll $(BUILD_DIR)/$(testp).exe $(BUILD_DIR)/$(testc).exe $(BUILD_DIR)/$(testc).obj
 
 
 samples: all
-	$(CC) $(CFLAGS) -I. /Fe:simple  sample\simple.c  $(dlllib)
-	$(CC) $(CFLAGS) -I. /Fe:posix   sample\posix.c   $(dlllib)
-	$(CC) $(CFLAGS) -I. /Fe:names   sample\names.c   $(dlllib)
-	$(CC) $(CFLAGS) -I. /Fe:listcap sample\listcap.c $(dlllib)
-	$(CC) $(CFLAGS) -I. /Fe:sql     sample\sql.c     $(dlllib)
-	$(CC) $(CFLAGS) -I. /Fe:encode  sample\encode.c  $(dlllib)
-	$(CC) $(CFLAGS) -I. /Fe:syntax  sample\syntax.c  $(dlllib)
+	$(CC) $(CFLAGS) -I. -o simple  $(ONIG_DIR)\sample\simple.c  $(dlllib)
+	$(CC) $(CFLAGS) -I. -o posix   $(ONIG_DIR)\sample\posix.c   $(dlllib)
+	$(CC) $(CFLAGS) -I. -o names   $(ONIG_DIR)\sample\names.c   $(dlllib)
+	$(CC) $(CFLAGS) -I. -o listcap $(ONIG_DIR)\sample\listcap.c $(dlllib)
+	$(CC) $(CFLAGS) -I. -o sql     $(ONIG_DIR)\sample\sql.c     $(dlllib)
+	$(CC) $(CFLAGS) -I. -o encode  $(ONIG_DIR)\sample\encode.c  $(dlllib)
+	$(CC) $(CFLAGS) -I. -o syntax  $(ONIG_DIR)\sample\syntax.c  $(dlllib)


### PR DESCRIPTION
The current windows NMAKE makefile system produces build artifacts in a fixed directory structure in the source directory. This pull requeqest ports [changes made in the `rust-onig` project](https://github.com/rust-onig/rust-onig/issues/49) to allow out-of-tree builds. This functionality was useful in `rust-onig` to allow the build artifacts and finished product to be placed in the same intermediate build directory as compiled Rust assets.

 