### PR TITLE
Remove unused defines from Windows configure file

### DIFF
--- a/src/config.h.win32
+++ b/src/config.h.win32
@@ -35,8 +35,6 @@
 #define HAVE_MEMORY_H 1
 #define uid_t int
 #define gid_t int
-#define HAVE_STRUCT_STAT_ST_RDEV 1
-#define HAVE_ST_RDEV 1
 #define GETGROUPS_T int
 #define RETSIGTYPE void
 #define HAVE_ALLOCA 1

--- a/src/config.h.win64
+++ b/src/config.h.win64
@@ -35,8 +35,6 @@
 #define HAVE_MEMORY_H 1
 #define uid_t int
 #define gid_t int
-#define HAVE_STRUCT_STAT_ST_RDEV 1
-#define HAVE_ST_RDEV 1
 #define GETGROUPS_T int
 #define RETSIGTYPE void
 #define HAVE_ALLOCA 1


### PR DESCRIPTION
Hello, the definitions of the `HAVE_ST_RDEV` and `HAVE_STRUCT_STAT_ST_RDEV` would provide checks for the members of the stat struct. Since the st_rdev member is not used in this code these checks can be simplified by removal.

Thanks for checking this out or considering merging it.