### PR TITLE
Replace obsolete AC_TRY_COMPILE with AC_COMPILE_IFELSE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,15 +64,17 @@ AC_FUNC_ALLOCA
 AC_FUNC_MEMCMP
 
 AC_CACHE_CHECK(for prototypes, _cv_have_prototypes,
-  [AC_TRY_COMPILE([int foo(int x) { return 0; }], [return foo(10);],
-	_cv_have_prototypes=yes,
-	_cv_have_prototypes=no)])
+  [AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM([[int foo(int x) { return 0; }]],
+      [[return foo(10);]])],
+    [_cv_have_prototypes=yes],
+    [_cv_have_prototypes=no])])
 if test "$_cv_have_prototypes" = yes; then
   AC_DEFINE(HAVE_PROTOTYPES,1,[Define if compilerr supports prototypes])
 fi
 
 AC_CACHE_CHECK(for variable length prototypes and stdarg.h, _cv_stdarg,
-  [AC_TRY_COMPILE([
+  [AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <stdarg.h>
 int foo(int x, ...) {
 	va_list va;
@@ -82,9 +84,7 @@ int foo(int x, ...) {
 	va_arg(va, double);
 	return 0;
 }
-], [return foo(10, "", 3.14);],
-	_cv_stdarg=yes,
-	_cv_stdarg=no)])
+]], [[return foo(10, "", 3.14);]])],[_cv_stdarg=yes],[_cv_stdarg=no])])
 if test "$_cv_stdarg" = yes; then
   AC_DEFINE(HAVE_STDARG_PROTOTYPES,1,[Define if compiler supports stdarg prototypes])
 fi


### PR DESCRIPTION
Hello,

Autoconf made several macros obsolete including the `AC_TRY_COMPILE` in 2001 in version 2.50:
- http://git.savannah.gnu.org/cgit/autoconf.git/tree/ChangeLog.2
- http://git.savannah.gnu.org/cgit/autoconf.git/tree/ChangeLog.3

It should be replaced with the current `AC_COMPILE_IFELSE instead`.

Reference docs: 
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/AC_005fFOO_005fIFELSE-vs-AC_005fTRY_005fFOO.html

Thank you for considering merging this or checking it out. In case of doubts or questions just ask...
