### PR TITLE
Replace AC_CONFIG_HEADER with AC_CONFIG_HEADERS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_INIT(onig, 6.8.2)
 AC_CONFIG_MACRO_DIR([m4])
 
 AM_INIT_AUTOMAKE([-Wno-portability 1.14])
-AC_CONFIG_HEADER(src/config.h)
+AC_CONFIG_HEADERS([src/config.h])
 
 
 dnl default value for STATISTICS


### PR DESCRIPTION
Hello,

Autoconf doesn't mention the `AC_CONFIG_HEADER` macro since the v2.13 released in 1999 anywhere in the documentation. Future of this macro is unclear and commented as possible candidate for obsoletion in the autoconf source code. Since it is just a wrapper around the main `AC_CONFIG_HEADERS` macro, the functionality is the same, and also more clear to find it in the autoconf documentation and avoid possible future obsoletion.

Autoconf source code where it has a comment for obsoletion since 2.59:

http://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/status.m4?h=branch-2.59#n435
Documentation mention AC_CONFIG_HEADERS and usage is the same:

https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Configuration-Headers.html
Also in Autoconf several changelogs mention the obsoletion path for it...

Thanks for considering merging this or checking it out.