### PR TITLE
Remove unused RETSIGTYPE

### DIFF
--- a/src/config.h.win32
+++ b/src/config.h.win32
@@ -36,7 +36,6 @@
 #define uid_t int
 #define gid_t int
 #define GETGROUPS_T int
-#define RETSIGTYPE void
 #define HAVE_ALLOCA 1
 #define HAVE_DUP2 1
 #define HAVE_MEMCMP 1

--- a/src/config.h.win64
+++ b/src/config.h.win64
@@ -36,7 +36,6 @@
 #define uid_t int
 #define gid_t int
 #define GETGROUPS_T int
-#define RETSIGTYPE void
 #define HAVE_ALLOCA 1
 #define HAVE_DUP2 1
 #define HAVE_MEMCMP 1


### PR DESCRIPTION
Hello,

The `RETSIGTYPE` defines the signal type. In K&R C, this could be `int` or `void`. Since C89 it is always `void`. Also the `RETSIGTYPE` is not used in current code.

This is usually also defined by the obsolete macro (AC_TYPE_SIGNAL](https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html) in autoconf.

Thanks for considering merging this, or checking it out.