### PR TITLE
Remove HAVE_FLOAT_H

### DIFF
--- a/src/config.h.win32
+++ b/src/config.h.win32
@@ -4,7 +4,6 @@
 #define HAVE_STDLIB_H 1
 #define HAVE_STRING_H 1
 #define HAVE_MEMORY_H 1
-#define HAVE_FLOAT_H 1
 #define HAVE_OFF_T 1
 #define SIZEOF_INT 4
 #define SIZEOF_SHORT 2

--- a/src/config.h.win64
+++ b/src/config.h.win64
@@ -4,7 +4,6 @@
 #define HAVE_STDLIB_H 1
 #define HAVE_STRING_H 1
 #define HAVE_MEMORY_H 1
-#define HAVE_FLOAT_H 1
 #define HAVE_OFF_T 1
 #define SIZEOF_INT 4
 #define SIZEOF_SHORT 2

--- a/src/config.h.windows.in
+++ b/src/config.h.windows.in
@@ -4,7 +4,6 @@
 #define HAVE_STDLIB_H 1
 #define HAVE_STRING_H 1
 #define HAVE_MEMORY_H 1
-#define HAVE_FLOAT_H 1
 #define HAVE_OFF_T 1
 #define SIZEOF_INT 4
 #define SIZEOF_SHORT 2


### PR DESCRIPTION
The `<float.h>` header file is part of the standard C89 headers [1] and
on current systems there is no need to do a manual check if header is
present anymore [2].

Build systems used to check for the presence of the header file and defined
the `HAVE_FLOAT_H` symbol.

Refs:
[1] https://port70.net/~nsz/c/c89/c89-draft.html#4.1.4
[2] http://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/headers.m4