### PR TITLE
Remove AC_FUNC_MEMCMP

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,7 +61,6 @@ AC_HEADER_TIME
 
 dnl Checks for library functions.
 AC_FUNC_ALLOCA
-AC_FUNC_MEMCMP
 
 AC_CACHE_CHECK(for prototypes, _cv_have_prototypes,
   [AC_COMPILE_IFELSE(


### PR DESCRIPTION
Autoconf 2.59d (released in 2006) [1] started promoting several macros
as not relevant for newer systems anymore, including the `AC_FUNC_MEMCMP`.

On some old systems such as SunOS 4.1.3 (EOL in 2003) and NeXT x86
OpenStep (discontinued) the `memcmp` function wasn't present or it
didn't work properly. [2]

On current systems including at least Solaris 10+ this check is not
relevant anymore.

Refs:
[1] http://git.savannah.gnu.org/cgit/autoconf.git/tree/NEWS
[2] https://www.gnu.org/software/autoconf/manual/autoconf-2.69/autoconf.html