### PR TITLE
Remove unused old symbols for string.h functions

### DIFF
--- a/src/config.h.win32
+++ b/src/config.h.win32
@@ -34,15 +34,10 @@
 #define GETGROUPS_T int
 #define HAVE_ALLOCA 1
 #define HAVE_DUP2 1
-#define HAVE_MEMCMP 1
-#define HAVE_MEMMOVE 1
 #define HAVE_MKDIR 1
 #define HAVE_STRCASECMP 1
 #define HAVE_STRNCASECMP 1
-#define HAVE_STRERROR 1
 #define HAVE_STRFTIME 1
-#define HAVE_STRCHR 1
-#define HAVE_STRSTR 1
 #define HAVE_STRTOD 1
 #define HAVE_STRTOL 1
 #define HAVE_STRTOUL 1

--- a/src/config.h.win64
+++ b/src/config.h.win64
@@ -34,15 +34,10 @@
 #define GETGROUPS_T int
 #define HAVE_ALLOCA 1
 #define HAVE_DUP2 1
-#define HAVE_MEMCMP 1
-#define HAVE_MEMMOVE 1
 #define HAVE_MKDIR 1
 #define HAVE_STRCASECMP 1
 #define HAVE_STRNCASECMP 1
-#define HAVE_STRERROR 1
 #define HAVE_STRFTIME 1
-#define HAVE_STRCHR 1
-#define HAVE_STRSTR 1
 #define HAVE_STRTOD 1
 #define HAVE_STRTOL 1
 #define HAVE_STRTOUL 1

--- a/src/config.h.windows.in
+++ b/src/config.h.windows.in
@@ -38,15 +38,10 @@
 #define GETGROUPS_T int
 #define HAVE_ALLOCA 1
 #define HAVE_DUP2 1
-#define HAVE_MEMCMP 1
-#define HAVE_MEMMOVE 1
 #define HAVE_MKDIR 1
 #define HAVE_STRCASECMP 1
 #define HAVE_STRNCASECMP 1
-#define HAVE_STRERROR 1
 #define HAVE_STRFTIME 1
-#define HAVE_STRCHR 1
-#define HAVE_STRSTR 1
 #define HAVE_STRTOD 1
 #define HAVE_STRTOL 1
 #define HAVE_STRTOUL 1


### PR DESCRIPTION
The C89 standard and later defines the <string.h> header as part of the
standard headers [1]. Functions memcmp, memmove, strerror, strchr, strstr,
and others are all part of C89 and <string.h> header definition.

Some build systems used to define the presence of these functions via
HAVE_MEMCMP, HAVE_MEMMOVE, HAVE_STRERROR, HAVE_STRCHR, HAVE_STRSTR
symbols. These aren't used in oniguruma library anymore and can be
ommitted from the config files for windows systems.

[1]: https://port70.net/~nsz/c/c89/c89-draft.html#4.11