### PR TITLE
Remove AC_C_CONST

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,7 +56,6 @@ dnl Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_SIZEOF(int, 4)
 AC_CHECK_SIZEOF(short, 2)
 AC_CHECK_SIZEOF(long, 4)
-AC_C_CONST
 
 dnl Checks for library functions.
 AC_FUNC_ALLOCA


### PR DESCRIPTION
Autoconf 2.59d (released in 2006) [1] started promoting several macros
as not relevant for newer systems, including the `AC_C_CONST`.

The `const` keyword is used in C since C89. On old systems some compilers
lacked the `const` and this macro defined it to be empty. This check was
relevant on systems with compilers before C89 and on current systems it
can be omitted since ˙const` is always available. [2]

Refs:
[1] http://git.savannah.gnu.org/cgit/autoconf.git/tree/NEWS
[2] https://www.gnu.org/software/autoconf/manual/autoconf-2.69/autoconf.html