### PR TITLE
Upgrade deprecated AC_OUTPUT macro call

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,5 +86,6 @@ if test "$_cv_stdarg" = yes; then
   AC_DEFINE(HAVE_STDARG_PROTOTYPES,1,[Define if compiler supports stdarg prototypes])
 fi
 
-
-AC_OUTPUT([Makefile src/Makefile test/Makefile sample/Makefile onig-config], [chmod +x onig-config])
+AC_CONFIG_FILES([Makefile src/Makefile test/Makefile sample/Makefile onig-config])
+AC_CONFIG_COMMANDS([default],[chmod +x onig-config],[])
+AC_OUTPUT


### PR DESCRIPTION
Autoconf 2.50 made several changes to macro calls. These include also
arguments passed to AC_OUTPUT macro. The upgrading chapter in Autoconf
documentation includes an example of using AC_OUTPUT with
AC_CONFIG_FILES and AC_CONFIG_COMMANDS:
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html

Systems out there should be well supported by now.

This patch was created with the help of autoupdate script:
autoupdate <file>

More info on where exactly this got deprecated:
- ftp://ftp.gnu.org/old-gnu/Manuals/autoconf-2.13/html_mono/autoconf.html
- ftp://ftp.auckland.ac.nz/pub/gnu/Manuals/autoconf-2.52/html_chapter/autoconf_15.html
- http://git.savannah.gnu.org/cgit/autoconf.git/tree/NEWS