### PR TITLE
Remove obsolescent AC_HEADER_STDC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,6 @@ check_include_files(inttypes.h  HAVE_INTTYPES_H)
 check_type_size(int SIZEOF_INT)
 check_type_size(long SIZEOF_LONG)
 check_type_size(short SIZEOF_SHORT)
-check_include_files("stdlib.h;stdarg.h;string.h;float.h" STDC_HEADERS)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/config.h.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 

--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,6 @@ AC_PROG_MAKE_SET
 dnl Checks for libraries.
 
 dnl Checks for header files.
-AC_HEADER_STDC
 AC_CHECK_HEADERS(strings.h sys/time.h unistd.h sys/times.h)
 
 dnl Checks for typedefs, structures, and compiler characteristics.

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -55,9 +55,6 @@
 /* The size of `short', as computed by sizeof. */
 #cmakedefine SIZEOF_SHORT  ${SIZEOF_SHORT}
 
-/* Define to 1 if you have the ANSI C header files. */
-#cmakedefine STDC_HEADERS  ${STDC_HEADERS}
-
 /* Define if enable CR+NL as line terminator */
 #cmakedefine USE_CRNL_AS_LINE_TERMINATOR  ${USE_CRNL_AS_LINE_TERMINATOR}
 

--- a/src/config.h.win32
+++ b/src/config.h.win32
@@ -1,4 +1,3 @@
-#define STDC_HEADERS 1
 #define HAVE_SYS_TYPES_H 1
 #define HAVE_SYS_STAT_H 1
 #define HAVE_MEMORY_H 1
@@ -23,7 +22,6 @@
 #endif
 #endif
 #define HAVE_DECL_SYS_NERR 1
-#define STDC_HEADERS 1
 #define HAVE_FCNTL_H 1
 #define HAVE_SYS_UTIME_H 1
 #define HAVE_MEMORY_H 1

--- a/src/config.h.win64
+++ b/src/config.h.win64
@@ -1,4 +1,3 @@
-#define STDC_HEADERS 1
 #define HAVE_SYS_TYPES_H 1
 #define HAVE_SYS_STAT_H 1
 #define HAVE_MEMORY_H 1
@@ -23,7 +22,6 @@
 #endif
 #endif
 #define HAVE_DECL_SYS_NERR 1
-#define STDC_HEADERS 1
 #define HAVE_FCNTL_H 1
 #define HAVE_SYS_UTIME_H 1
 #define HAVE_MEMORY_H 1

--- a/src/config.h.windows.in
+++ b/src/config.h.windows.in
@@ -1,4 +1,3 @@
-#define STDC_HEADERS 1
 #define HAVE_SYS_TYPES_H 1
 #define HAVE_SYS_STAT_H 1
 #define HAVE_MEMORY_H 1
@@ -27,7 +26,6 @@
 #endif
 #endif
 #define HAVE_DECL_SYS_NERR 1
-#define STDC_HEADERS 1
 #define HAVE_FCNTL_H 1
 #define HAVE_SYS_UTIME_H 1
 #define HAVE_MEMORY_H 1


### PR DESCRIPTION
Autoconf 2.59d (released in 2006) [1] started promoting several macros
as not relevant for newer systems anymore, including the `AC_HEADER_STDC`.

This macro checks if given system has C89 compliant header files such
as <string.h>, <stdlib.h>, <stdarg.h>, <float.h>,... and defines the
`STDC_HEADERS` symbol [2]. Case is that current systems should be well
supported with at least C89 standard headers [3].

Given headers are still additionally checked with the `AC_PROG_CC`
macro, yet not needed anyway.

For cmake build system this applies similarly and the manual custom
check of the standard headers can be removed likewise.

Refs:
[1] http://git.savannah.gnu.org/cgit/autoconf.git/tree/NEWS
[2] https://www.gnu.org/software/autoconf/manual/autoconf-2.69/autoconf.html
[3] https://port70.net/~nsz/c/c89/c89-draft.html#4.1.2