### PR TITLE
Remove HAVE_PROTOTYPES and HAVE_STDARG_PROTOTYPES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,6 @@ include(TestBigEndian)
 
 check_function_exists(alloca HAVE_ALLOCA)
 check_include_files(alloca.h HAVE_ALLOCA_H)
-set(HAVE_PROTOTYPES 1)
-check_include_files(stdarg.h    HAVE_STDARG_PROTOTYPES)
 check_include_files(stdint.h    HAVE_STDINT_H)
 check_include_files(strings.h   HAVE_STRINGS_H)
 check_include_files(sys/times.h HAVE_SYS_TIMES_H)

--- a/configure.ac
+++ b/configure.ac
@@ -59,32 +59,6 @@ AC_CHECK_SIZEOF(long, 4)
 dnl Checks for library functions.
 AC_FUNC_ALLOCA
 
-AC_CACHE_CHECK(for prototypes, _cv_have_prototypes,
-  [AC_COMPILE_IFELSE(
-    [AC_LANG_PROGRAM([[int foo(int x) { return 0; }]],
-      [[return foo(10);]])],
-    [_cv_have_prototypes=yes],
-    [_cv_have_prototypes=no])])
-if test "$_cv_have_prototypes" = yes; then
-  AC_DEFINE(HAVE_PROTOTYPES,1,[Define if compilerr supports prototypes])
-fi
-
-AC_CACHE_CHECK(for variable length prototypes and stdarg.h, _cv_stdarg,
-  [AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <stdarg.h>
-int foo(int x, ...) {
-	va_list va;
-	va_start(va, x);
-	va_arg(va, int);
-	va_arg(va, char *);
-	va_arg(va, double);
-	return 0;
-}
-]], [[return foo(10, "", 3.14);]])],[_cv_stdarg=yes],[_cv_stdarg=no])])
-if test "$_cv_stdarg" = yes; then
-  AC_DEFINE(HAVE_STDARG_PROTOTYPES,1,[Define if compiler supports stdarg prototypes])
-fi
-
 AC_CONFIG_FILES([Makefile src/Makefile test/Makefile sample/Makefile onig-config])
 AC_CONFIG_COMMANDS([default],[chmod +x onig-config],[])
 AC_OUTPUT

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -13,12 +13,6 @@
    */
 #cmakedefine HAVE_ALLOCA_H  ${HAVE_ALLOCA_H}
 
-/* Define if compilerr supports prototypes */
-#cmakedefine HAVE_PROTOTYPES  ${HAVE_PROTOTYPES}
-
-/* Define if compiler supports stdarg prototypes */
-#cmakedefine HAVE_STDARG_PROTOTYPES  ${HAVE_STDARG_PROTOTYPES}
-
 /* Define to 1 if you have the <stdint.h> header file. */
 #cmakedefine HAVE_STDINT_H  ${HAVE_STDINT_H}
 

--- a/src/config.h.win32
+++ b/src/config.h.win32
@@ -11,9 +11,7 @@
 #define SIZEOF_VOIDP 4
 #define SIZEOF_FLOAT 4
 #define SIZEOF_DOUBLE 8
-#define HAVE_PROTOTYPES 1
 #define TOKEN_PASTE(x,y) x##y
-#define HAVE_STDARG_PROTOTYPES 1
 #ifndef NORETURN
 #if _MSC_VER > 1100
 #define NORETURN(x) __declspec(noreturn) x

--- a/src/config.h.win64
+++ b/src/config.h.win64
@@ -11,9 +11,7 @@
 #define SIZEOF_VOIDP 8
 #define SIZEOF_FLOAT 4
 #define SIZEOF_DOUBLE 8
-#define HAVE_PROTOTYPES 1
 #define TOKEN_PASTE(x,y) x##y
-#define HAVE_STDARG_PROTOTYPES 1
 #ifndef NORETURN
 #if _MSC_VER > 1100
 #define NORETURN(x) __declspec(noreturn) x

--- a/src/config.h.windows.in
+++ b/src/config.h.windows.in
@@ -15,9 +15,7 @@
 #endif
 #define SIZEOF_FLOAT 4
 #define SIZEOF_DOUBLE 8
-#define HAVE_PROTOTYPES 1
 #define TOKEN_PASTE(x,y) x##y
-#define HAVE_STDARG_PROTOTYPES 1
 #ifndef NORETURN
 #if _MSC_VER > 1100
 #define NORETURN(x) __declspec(noreturn) x

--- a/src/regerror.c
+++ b/src/regerror.c
@@ -30,13 +30,7 @@
 #include "regint.h"
 #include <stdio.h> /* for vsnprintf() */
 
-#ifdef HAVE_STDARG_PROTOTYPES
 #include <stdarg.h>
-#define va_init_list(a,b) va_start(a,b)
-#else
-#include <varargs.h>
-#define va_init_list(a,b) va_start(a)
-#endif
 
 extern UChar*
 onig_error_code_to_format(int code)
@@ -262,15 +256,7 @@ static int to_ascii(OnigEncoding enc, UChar *s, UChar *end,
 /* for ONIG_MAX_ERROR_MESSAGE_LEN */
 #define MAX_ERROR_PAR_LEN   30
 
-extern int
-#ifdef HAVE_STDARG_PROTOTYPES
-onig_error_code_to_str(UChar* s, int code, ...)
-#else
-onig_error_code_to_str(s, code, va_alist)
-  UChar* s;
-  int code;
-  va_dcl
-#endif
+extern int onig_error_code_to_str(UChar* s, int code, ...)
 {
   UChar *p, *q;
   OnigErrorInfo* einfo;
@@ -278,7 +264,7 @@ onig_error_code_to_str(s, code, va_alist)
   UChar parbuf[MAX_ERROR_PAR_LEN];
   va_list vargs;
 
-  va_init_list(vargs, code);
+  va_start(vargs, code);
 
   switch (code) {
   case ONIGERR_UNDEFINED_NAME_REFERENCE:
@@ -330,27 +316,15 @@ onig_error_code_to_str(s, code, va_alist)
 }
 
 
-void
-#ifdef HAVE_STDARG_PROTOTYPES
-onig_snprintf_with_pattern(UChar buf[], int bufsize, OnigEncoding enc,
-                           UChar* pat, UChar* pat_end, const UChar *fmt, ...)
-#else
-onig_snprintf_with_pattern(buf, bufsize, enc, pat, pat_end, fmt, va_alist)
-    UChar buf[];
-    int bufsize;
-    OnigEncoding enc;
-    UChar* pat;
-    UChar* pat_end;
-    const UChar *fmt;
-    va_dcl
-#endif
+void onig_snprintf_with_pattern(UChar buf[], int bufsize, OnigEncoding enc,
+                                UChar* pat, UChar* pat_end, const UChar *fmt, ...)
 {
   int n, need, len;
   UChar *p, *s, *bp;
   UChar bs[6];
   va_list args;
 
-  va_init_list(args, fmt);
+  va_start(args, fmt);
   n = xvsnprintf((char* )buf, bufsize, (const char* )fmt, args);
   va_end(args);
 

--- a/src/regint.h
+++ b/src/regint.h
@@ -72,26 +72,6 @@
 
 #include "regenc.h"
 
-#ifdef __cplusplus
-# ifndef  HAVE_STDARG_PROTOTYPES
-#  define HAVE_STDARG_PROTOTYPES 1
-# endif
-#endif
-
-/* escape Mac OS X/Xcode 2.4/gcc 4.0.1 problem */
-#if defined(__APPLE__) && defined(__GNUC__) && __GNUC__ >= 4
-# ifndef  HAVE_STDARG_PROTOTYPES
-#  define HAVE_STDARG_PROTOTYPES 1
-# endif
-#endif
-
-#ifdef HAVE_STDARG_H
-# ifndef  HAVE_STDARG_PROTOTYPES
-#  define HAVE_STDARG_PROTOTYPES 1
-# endif
-#endif
-
-
 #define INIT_MATCH_STACK_SIZE                     160
 #define DEFAULT_MATCH_STACK_LIMIT_SIZE              0 /* unlimited */
 #define DEFAULT_RETRY_LIMIT_IN_MATCH         10000000


### PR DESCRIPTION
Hello,

The C89 standard and later defines the `<stdarg.h>` header as part of the standard headers [1] and on current systems it is always present.

Checking for presence and functionality of the `<stdarg.h>` header and variadic functions is not relevant anymore on current systems since this is always available.

Also Autoconf suggests doing this and relying on C89 or above [2] and [3].

As an alternative, outdated versions of POSIX defined the legacy header `<varargs.h>` [4].

This patch modernize the `<stdarg.h>` usage a bit.

Unused internal macro `va_init_list()` has been replaced with `va_start()`.

Checking if functions support prototypes is also not relevant anymore so the `HAVE_PROTOTYPES` symbol has been removed likewise.

Refs:
[1] https://port70.net/~nsz/c/c89/c89-draft.html#4.1.2
[2] http://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/headers.m4
[3] https://www.gnu.org/software/autoconf/manual/autoconf-2.69/autoconf.html
[4] https://en.wikipedia.org/wiki/Stdarg.h#varargs.h

In case I've missed something let me know. Thank you.