### PR TITLE
Set SIZEOF_SIZE_T for windows platforms

### DIFF
--- a/src/config.h.win32
+++ b/src/config.h.win32
@@ -11,6 +11,7 @@
 #define SIZEOF_VOIDP 4
 #define SIZEOF_FLOAT 4
 #define SIZEOF_DOUBLE 8
+#define SIZEOF_SIZE_T 4
 #define TOKEN_PASTE(x,y) x##y
 #ifndef NORETURN
 #if _MSC_VER > 1100

--- a/src/config.h.win64
+++ b/src/config.h.win64
@@ -11,6 +11,7 @@
 #define SIZEOF_VOIDP 8
 #define SIZEOF_FLOAT 4
 #define SIZEOF_DOUBLE 8
+#define SIZEOF_SIZE_T 8
 #define TOKEN_PASTE(x,y) x##y
 #ifndef NORETURN
 #if _MSC_VER > 1100


### PR DESCRIPTION
Hello, the size of `size_t` is 4 bytes on 32bit Windows platforms and 8 bytes on 64bit Windows platforms. This patch defines the SIZEOF_SIZE_T symbols for both instead of using only 4 for both.

Ref:
- https://msdn.microsoft.com/en-us/library/3b2e7499.aspx

This patch has been done with help from the [PHP patch](https://github.com/php/php-src/blob/master/ext/mbstring/oniguruma.patch).

Thank you.