### PR TITLE
regerror/toascii: do not attempt to serialize NULL pointer

### DIFF
--- a/src/regerror.c
+++ b/src/regerror.c
@@ -211,7 +211,11 @@ static int to_ascii(OnigEncoding enc, UChar *s, UChar *end,
   UChar *p;
   OnigCodePoint code;
 
-  if (ONIGENC_MBC_MINLEN(enc) > 1) {
+  if (!s) {
+    len = 0;
+    *is_over = 0;
+  }
+  else if (ONIGENC_MBC_MINLEN(enc) > 1) {
     p = s;
     len = 0;
     while (p < end) {


### PR DESCRIPTION
This has been seen in the wild, e.g.  [1], and while I have not investigated
how a NULL made it in here, this should prevent similar future bugs causing
a SEGFAULT.

[1] https://github.com/stedolan/jq/issues/1803