### PR TITLE
Remove unused HAVE_VSNPRINTF

### DIFF
--- a/src/config.h.win32
+++ b/src/config.h.win32
@@ -31,7 +31,6 @@
 #define HAVE_DUP2 1
 #define HAVE_MKDIR 1
 #define HAVE_FLOCK 1
-#define HAVE_VSNPRINTF 1
 #define HAVE_FINITE 1
 #define HAVE_HYPOT 1
 #define HAVE_WAITPID 1

--- a/src/config.h.win64
+++ b/src/config.h.win64
@@ -31,7 +31,6 @@
 #define HAVE_DUP2 1
 #define HAVE_MKDIR 1
 #define HAVE_FLOCK 1
-#define HAVE_VSNPRINTF 1
 #define HAVE_FINITE 1
 #define HAVE_HYPOT 1
 #define HAVE_WAITPID 1

--- a/src/config.h.windows.in
+++ b/src/config.h.windows.in
@@ -36,7 +36,6 @@
 #define HAVE_DUP2 1
 #define HAVE_MKDIR 1
 #define HAVE_FLOCK 1
-#define HAVE_VSNPRINTF 1
 #define HAVE_FINITE 1
 #define HAVE_HYPOT 1
 #define HAVE_WAITPID 1


### PR DESCRIPTION
The symbol HAVE_VSNPRINTF was once used for checks if vsnprintf can be used. Today this symbol is not used in oniguruma library anymore.

Thank you.