### PR TITLE
Sync AC_CHECK_SIZEOF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,6 @@ check_include_files(unistd.h    HAVE_UNISTD_H)
 check_include_files(inttypes.h  HAVE_INTTYPES_H)
 check_type_size(int SIZEOF_INT)
 check_type_size(long SIZEOF_LONG)
-check_type_size(short SIZEOF_SHORT)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/config.h.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 

--- a/configure.ac
+++ b/configure.ac
@@ -52,9 +52,8 @@ dnl Checks for header files.
 AC_CHECK_HEADERS(sys/time.h unistd.h sys/times.h)
 
 dnl Checks for typedefs, structures, and compiler characteristics.
-AC_CHECK_SIZEOF(int, 4)
-AC_CHECK_SIZEOF(short, 2)
-AC_CHECK_SIZEOF(long, 4)
+AC_CHECK_SIZEOF([int])
+AC_CHECK_SIZEOF([long])
 
 dnl Checks for library functions.
 AC_FUNC_ALLOCA

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -43,9 +43,6 @@
 /* The size of `long', as computed by sizeof. */
 #cmakedefine SIZEOF_LONG  ${SIZEOF_LONG}
 
-/* The size of `short', as computed by sizeof. */
-#cmakedefine SIZEOF_SHORT  ${SIZEOF_SHORT}
-
 /* Define if enable CR+NL as line terminator */
 #cmakedefine USE_CRNL_AS_LINE_TERMINATOR  ${USE_CRNL_AS_LINE_TERMINATOR}
 

--- a/src/config.h.win32
+++ b/src/config.h.win32
@@ -3,7 +3,6 @@
 #define HAVE_MEMORY_H 1
 #define HAVE_OFF_T 1
 #define SIZEOF_INT 4
-#define SIZEOF_SHORT 2
 #define SIZEOF_LONG 4
 #define SIZEOF_LONG_LONG 8
 #define SIZEOF___INT64 8

--- a/src/config.h.win64
+++ b/src/config.h.win64
@@ -3,7 +3,6 @@
 #define HAVE_MEMORY_H 1
 #define HAVE_OFF_T 1
 #define SIZEOF_INT 4
-#define SIZEOF_SHORT 2
 #define SIZEOF_LONG 4
 #define SIZEOF_LONG_LONG 8
 #define SIZEOF___INT64 8

--- a/src/config.h.windows.in
+++ b/src/config.h.windows.in
@@ -3,7 +3,6 @@
 #define HAVE_MEMORY_H 1
 #define HAVE_OFF_T 1
 #define SIZEOF_INT 4
-#define SIZEOF_SHORT 2
 #define SIZEOF_LONG 4
 #define SIZEOF_LONG_LONG 8
 #define SIZEOF___INT64 8


### PR DESCRIPTION
- SIZEOF_SHORT removed since it is not used
- second argument in the AC_CHECK_SIZEOF is not used anymore and can be
  removed.