### PR TITLE
Add MSVC_STATIC_RUNTIME option in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,28 +1,19 @@
 cmake_minimum_required(VERSION 3.1)
-project(oniguruma VERSION 6.9.2)
+project(oniguruma
+  VERSION 6.9.2
+  LANGUAGES C)
 
 set(PACKAGE onig)
 set(PACKAGE_VERSION ${PROJECT_VERSION})
 
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(ENABLE_POSIX_API  "Include POSIX API" ON)
+if(MSVC)
+  option(MSVC_STATIC_RUNTIME "Build with static runtime" OFF)
+endif()
 
 set(USE_CRNL_AS_LINE_TERMINATOR 0)
 set(VERSION ${PACKAGE_VERSION})
-
-if(MSVC)
-  # Force to always compile with W4
-  if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
-    string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-  else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
-  endif()
-elseif(CMAKE_COMPILER_IS_GNUCXX)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-elseif(CMAKE_COMPILER_IS_GNUCC)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
-endif()
-
 
 include(CheckCSourceCompiles)
 include(CheckIncludeFiles)
@@ -72,6 +63,25 @@ add_library(onig ${_SRCS})
 target_include_directories(onig PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+
+if(MSVC)
+  target_compile_options(onig PRIVATE
+	#/W4
+	)
+  if(MSVC_STATIC_RUNTIME)
+	target_compile_options(onig PRIVATE
+	  $<$<CONFIG:Release>:/MT>
+	  $<$<CONFIG:Debug>:/MTd>
+	  $<$<CONFIG:MinSizeRel>:/MT>
+	  $<$<CONFIG:RelWithDebgInfo>:/MTd>
+	  )
+  endif()
+elseif(CMAKE_COMPILER_IS_GNUCC)
+  target_compile_options(onig PRIVATE
+	-Wall
+	)
+endif()
+
 
 # Installation (https://github.com/forexample/package-example)
 


### PR DESCRIPTION
I need static library oniguruma library with static runtime.
It can be generated by this PR.

    cmake .. -G "Visual Studio 16 2019" -DBUILD_SHARED_LIBS=OFF -DMSVC_STATIC_RUNTIME=ON

And this PR replace set() and string(REGEX REPLACE).
with target_compile_options()
