### PR TITLE
Fix static build error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ if(MSVC)
 	  $<$<CONFIG:MinSizeRel>:/MT>
 	  $<$<CONFIG:RelWithDebgInfo>:/MTd>
 	  )
-	target_compile_definitions(onig PUBLIC -DONIG_EXTERN=)
+	target_compile_definitions(onig PUBLIC -DONIG_STATIC)
   endif()
 elseif(CMAKE_COMPILER_IS_GNUCC)
   target_compile_options(onig PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ if(MSVC)
 	  $<$<CONFIG:MinSizeRel>:/MT>
 	  $<$<CONFIG:RelWithDebgInfo>:/MTd>
 	  )
+	target_compile_definitions(onig PUBLIC -DONIG_EXTERN=)
   endif()
 elseif(CMAKE_COMPILER_IS_GNUCC)
   target_compile_options(onig PRIVATE

--- a/src/oniguruma.h
+++ b/src/oniguruma.h
@@ -52,6 +52,7 @@ extern "C" {
 # define PV_(args) args
 #endif
 
+#ifndef ONIG_STATIC
 #ifndef ONIG_EXTERN
 #if defined(_WIN32) && !defined(__GNUC__)
 #if defined(ONIGURUMA_EXPORT)
@@ -63,6 +64,9 @@ extern "C" {
 #endif
 
 #ifndef ONIG_EXTERN
+#define ONIG_EXTERN   extern
+#endif
+#else
 #define ONIG_EXTERN   extern
 #endif
 


### PR DESCRIPTION
ONIG_EXTERN is defined wrong in windows static build.