### PR TITLE
Enable oniguruma to build on wasm32-unknown-unknown target

### DIFF
--- a/src/regexec.c
+++ b/src/regexec.c
@@ -27,6 +27,7 @@
  * SUCH DAMAGE.
  */
 #include "regint.h"
+#include <stdint.h>
 
 #define IS_MBC_WORD_ASCII_MODE(enc,s,end,mode) \
   ((mode) == 0 ? ONIGENC_IS_MBC_WORD(enc,s,end) : ONIGENC_IS_MBC_WORD_ASCII(enc,s,end))
@@ -375,7 +376,7 @@ print_compiled_byte_code(FILE* f, regex_t* reg, int index,
   case OP_CCLASS_MB_NOT:
     {
       OnigCodePoint ncode;
-      OnigCodePoint* codes;      
+      OnigCodePoint* codes;
 
       codes = (OnigCodePoint* )p->cclass_mb.mb;
       GET_CODE_POINT(ncode, codes);

--- a/src/regint.h
+++ b/src/regint.h
@@ -54,8 +54,10 @@
 #define PLATFORM_UNALIGNED_WORD_ACCESS
 #endif
 
+#ifndef ONIG_DISABLE_DIRECT_THREADING
 #ifdef __GNUC__
 #define USE_GOTO_LABELS_AS_VALUES
+#endif
 #endif
 
 /* config */

--- a/src/regparse.c
+++ b/src/regparse.c
@@ -29,6 +29,7 @@
 
 #include "regparse.h"
 #include "st.h"
+#include <stdint.h>
 
 #ifdef DEBUG_NODE_FREE
 #include <stdio.h>


### PR DESCRIPTION
This PR adds support for building oniguruma under the wasm32-unknown-unknown target with clang-8 or newer. There are two commits:

## Add macro to disable direct threading

The oniguruma match engine has a direct threaded loop. The library detects whether to use this implementation by checking for a GCC compiler via the `__GNUC__` macro.

clang pretends to be GCC so threading is enabled for clang.

Until very recently, clang did not support threading ("computed gotos") under wasm targets. This is [fixed in trunk clang](https://bugs.llvm.org/show_bug.cgi?id=42498).

To unblock building wasm targets on older clang, add a macro that, when defined, disables threading regardless of the compiler.

This approach is [similar to the approach taken by mruby](https://github.com/mruby/mruby/blob/8ed15fd92e6d3ce7963db8c3162bdebee7b55e1b/src/vm.c#L905-L928), which uses direct threading in the VM bytecode interpreter.

## Explicitly `#include <stdint.h>`

`intptr_t` and `uintptr_t` are C99 types but they are optional. At least clang-9 and the emscripten headers I'm using to compile oniguruma do not automatically define these types for wasm targets.