### PR TITLE
Initialize potentially-uninitialized variables

### DIFF
--- a/src/regcomp.c
+++ b/src/regcomp.c
@@ -6304,7 +6304,7 @@ onig_compile(regex_t* reg, const UChar* pattern, const UChar* pattern_end,
   Node*  root;
   ScanEnv  scan_env;
 #ifdef USE_CALL
-  UnsetAddrList  uslist;
+  UnsetAddrList  uslist = {0};
 #endif
 
   root = 0;

--- a/src/regexec.c
+++ b/src/regexec.c
@@ -4044,14 +4044,14 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
         OnigCalloutFunc func;
         OnigCalloutArgs args;
 
-        of = ONIG_CALLOUT_OF_NAME;
-        name_id = p->callout_name.id;
-        mem     = p->callout_name.num;
+        of  = ONIG_CALLOUT_OF_NAME;
+        mem = p->callout_name.num;
 
       callout_common_entry:
         e = onig_reg_callout_list_at(reg, mem);
         in = e->in;
         if (of == ONIG_CALLOUT_OF_NAME) {
+          name_id = p->callout_name.id;
           func = onig_get_callout_start_func(reg, mem);
         }
         else {

--- a/src/regparse.c
+++ b/src/regparse.c
@@ -6263,7 +6263,7 @@ parse_char_class(Node** np, PToken* tok, UChar** src, UChar* end, ScanEnv* env)
   CClassNode work_cc;
 
   enum CCSTATE state;
-  enum CCVALTYPE val_type, in_type;
+  enum CCVALTYPE val_type = -1, in_type;
   int val_israw, in_israw;
 
   *np = NULL_NODE;
@@ -6783,7 +6783,7 @@ parse_callout_args(int skip_mode, int cterm, UChar** src, UChar* end,
   UChar* s;
   UChar* e;
   UChar* eesc;
-  OnigCodePoint c;
+  OnigCodePoint c = 0;
   UChar* bufend;
   UChar buf[MAX_CALLOUT_ARG_BYTE_LENGTH];
   OnigEncoding enc = env->enc;
@@ -6793,7 +6793,6 @@ parse_callout_args(int skip_mode, int cterm, UChar** src, UChar* end,
 
   n = 0;
   while (n < ONIG_CALLOUT_MAX_ARGS_NUM) {
-    c   = 0;
     cn  = 0;
     esc = 0;
     eesc = 0;


### PR DESCRIPTION
This fixes some of the issues found by clang analyzer. 

Of these, `name_id` seems to be a legit bug — `goto callout_common_entry` skipped over its initialization.
