### PR TITLE
Fix MSVC build

### DIFF
--- a/src/config.h.win32
+++ b/src/config.h.win32
@@ -1,4 +1,5 @@
 #define HAVE_SYS_TYPES_H 1
+#define HAVE_STDINT_H 1
 #define HAVE_SYS_STAT_H 1
 #define HAVE_MEMORY_H 1
 #define HAVE_OFF_T 1

--- a/src/config.h.win64
+++ b/src/config.h.win64
@@ -1,4 +1,5 @@
 #define HAVE_SYS_TYPES_H 1
+#define HAVE_STDINT_H 1
 #define HAVE_SYS_STAT_H 1
 #define HAVE_MEMORY_H 1
 #define HAVE_OFF_T 1

--- a/src/config.h.windows.in
+++ b/src/config.h.windows.in
@@ -1,4 +1,5 @@
 #define HAVE_SYS_TYPES_H 1
+#define HAVE_STDINT_H 1
 #define HAVE_SYS_STAT_H 1
 #define HAVE_MEMORY_H 1
 #define HAVE_OFF_T 1


### PR DESCRIPTION
As of commit e75db3c[1], regint.h won't build anymore, since <stdint.h>
is now required, but not included for MSVC due to `HAVE_STDINT_H` not
being defined.  Since <stdint.h> is available as of VS 2015 (and likely
even as of VS 2010), we define it unconditionally.

[1] <https://github.com/kkos/oniguruma/commit/e75db3c9b4b4f52a769c4ab494a25e3ce069944e>

---

Since the build error is a regression from Oniguruma 6.9.3, it would be great if it can be included in 6.9.4.