### PR TITLE
It make a warning.

### DIFF
--- a/src/regcomp.c
+++ b/src/regcomp.c
@@ -2079,7 +2079,7 @@ compile_anchor_node(AnchorNode* node, regex_t* reg, ScanEnv* env)
 static int
 compile_gimmick_node(GimmickNode* node, regex_t* reg)
 {
-  int r;
+  int r = 0;
 
   switch (node->type) {
   case GIMMICK_FAIL:


### PR DESCRIPTION
regcomp.c: In function ‘compile_bag_node’:
regcomp.c:1038:8: warning: ‘r’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 1038 |     if (r != 0) return r;
      |        ^
regcomp.c:2082:7: note: ‘r’ was declared here
 2082 |   int r;
      |       ^