### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,16 @@ Install
 
    (I have checked by Visual Studio Community 2015)
 
+Alternatively, you can build and install oniguruma using [vcpkg](https://github.com/microsoft/vcpkg/) dependency manager:
 
+   1. git clone https://github.com/Microsoft/vcpkg.git
+   2. cd vcpkg
+   3. ./bootstrap-vcpkg.bat
+   4. ./vcpkg integrate install
+   5. ./vcpkg install oniguruma
+
+The oniguruma port in vcpkg is kept up to date by microsoft team members and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 Regular Expressions
 -------------------


### PR DESCRIPTION
oniguruma is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build oniguruma, ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for oniguruma and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.