### PR TITLE
Add SOVERSION info to library when using cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,19 @@ target_include_directories(onig PUBLIC
 target_compile_definitions(onig PUBLIC
   $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:ONIG_STATIC>)
 
+if(BUILD_SHARED_LIBS)
+  # Parse SOVERSION information from LTVERSION in configure.ac
+  file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/configure.ac" LTVERSION REGEX "^LTVERSION *= *\"?[0-9]+:[0-9]+:[0-9]+\"?")
+  string(REGEX REPLACE "^LTVERSION *= *\"?([0-9]+:[0-9]+:[0-9]+)\"?.*$" "\\1" LTVERSION "${LTVERSION}")
+  string(REGEX REPLACE "^([0-9]+):([0-9]+):([0-9]+)" "\\1" LTCURRENT ${LTVERSION})
+  string(REGEX REPLACE "^([0-9]+):([0-9]+):([0-9]+)" "\\2" LTREVISION ${LTVERSION})
+  string(REGEX REPLACE "^([0-9]+):([0-9]+):([0-9]+)" "\\3" LTAGE ${LTVERSION})
+  math(EXPR ONIG_SOVERSION "${LTCURRENT} - ${LTAGE}")
+  set_target_properties(onig PROPERTIES
+      SOVERSION "${ONIG_SOVERSION}"
+      VERSION "${ONIG_SOVERSION}.${LTAGE}.${LTREVISION}")
+endif()
+
 if(MSVC)
   target_compile_options(onig PRIVATE
 	#/W4


### PR DESCRIPTION
Currently the SOVERSION is different when building with cmake than the
value used by autotools.
This adds the version information from autotools to cmake.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---
Current cmake-built library have no version information.  This PR makes cmake behavior equal to autotools.

I'm just not sure what to do about Windows builds.  It uses the VERSION property, but I'm not experienced with Windows enough to tell if the semantics are the same as the soname.  I believe libtool can build Windows libraries, and will use the same version scheme, so I'm leaving it the same as other systems.  Alternatively, the package version can be used instead, or we may leave it without version information.
I have tested this with Gentoo Linux.
