### PR TITLE
fix: check CalloutNameEntry for NULL before access

### DIFF
--- a/src/regparse.c
+++ b/src/regparse.c
@@ -1296,7 +1296,9 @@ static int
 i_free_callout_name_entry(st_callout_name_key* key, CalloutNameEntry* e,
                           void* arg ARG_UNUSED)
 {
-  xfree(e->name);
+  if (IS_NOT_NULL(e)) {
+    xfree(e->name);
+  }
   /*xfree(key->s); */ /* is same as e->name */
   xfree(key);
   xfree(e);


### PR DESCRIPTION
This fixes a php segfault, see
https://github.com/openwrt/packages/issues/12403

I traced it down with gdb
0xb6e37f70 in i_free_callout_name_entry (key=0x369040,
  e=0x0, arg=0x37afe0) at oniguruma-6.9.5_rev1/src/regparse.c:1297