### PR TITLE
Initial TIS-CI configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Code Quality: Cpp](https://img.shields.io/lgtm/grade/cpp/g/kkos/oniguruma.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/kkos/oniguruma/context:cpp)
 [![Total Alerts](https://img.shields.io/lgtm/alerts/g/kkos/oniguruma.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/kkos/oniguruma/alerts)
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/oniguruma.svg)](https://oss-fuzz-build-logs.storage.googleapis.com/index.html#oniguruma)
+[![TrustInSoft CI](https://ci.trust-in-soft.com/projects/kkos/oniguruma.svg?branch=master)](https://ci.trust-in-soft.com/projects/kkos/oniguruma)
 
 Oniguruma
 =========

--- a/test/test_back.c
+++ b/test/test_back.c
@@ -18,6 +18,10 @@ static int nsucc  = 0;
 static int nfail  = 0;
 static int nerror = 0;
 
+#ifdef __TRUSTINSOFT_ANALYZER__
+static int nall = 0;
+#endif
+
 static FILE* err_file;
 
 static OnigRegion* region;
@@ -25,6 +29,10 @@ static OnigRegion* region;
 static void xx(char* pattern, char* str, int from, int to, int mem, int not,
                int error_no, int line_no)
 {
+#ifdef __TRUSTINSOFT_ANALYZER__
+  if (nall++ % TIS_TEST_CHOOSE_MAX != TIS_TEST_CHOOSE_CURRENT) return;
+#endif
+
   int r;
   regex_t* reg;
   OnigErrorInfo einfo;

--- a/test/test_syntax.c
+++ b/test/test_syntax.c
@@ -17,6 +17,10 @@ static int nsucc  = 0;
 static int nfail  = 0;
 static int nerror = 0;
 
+#ifdef __TRUSTINSOFT_ANALYZER__
+static int nall = 0;
+#endif
+
 static FILE* err_file;
 
 static OnigRegion* region;
@@ -26,6 +30,10 @@ static OnigSyntaxType* Syntax;
 static void xx(char* pattern, char* str, int from, int to, int mem, int not,
                int error_no)
 {
+#ifdef __TRUSTINSOFT_ANALYZER__
+  if (nall++ % TIS_TEST_CHOOSE_MAX != TIS_TEST_CHOOSE_CURRENT) return;
+#endif
+
   int r;
   regex_t* reg;
   OnigErrorInfo einfo;

--- a/test/test_utf8.c
+++ b/test/test_utf8.c
@@ -18,6 +18,10 @@ static int nsucc  = 0;
 static int nfail  = 0;
 static int nerror = 0;
 
+#ifdef __TRUSTINSOFT_ANALYZER__
+static int nall = 0;
+#endif
+
 static FILE* err_file;
 
 static OnigRegion* region;
@@ -25,6 +29,10 @@ static OnigRegion* region;
 static void xx(char* pattern, char* str, int from, int to, int mem, int not,
                int error_no)
 {
+#ifdef __TRUSTINSOFT_ANALYZER__
+  if (nall++ % TIS_TEST_CHOOSE_MAX != TIS_TEST_CHOOSE_CURRENT) return;
+#endif
+
   int r;
   regex_t* reg;
   OnigErrorInfo einfo;

--- a/test/testc.c
+++ b/test/testc.c
@@ -14,11 +14,19 @@ static int nsucc  = 0;
 static int nfail  = 0;
 static int nerror = 0;
 
+#ifdef __TRUSTINSOFT_ANALYZER__
+static int nall = 0;
+#endif
+
 static FILE* err_file;
 static OnigRegion* region;
 
 static void xx(char* pattern, char* str, int from, int to, int mem, int not)
 {
+#ifdef __TRUSTINSOFT_ANALYZER__
+  if (nall++ % TIS_TEST_CHOOSE_MAX != TIS_TEST_CHOOSE_CURRENT) return;
+#endif
+
   int r;
   regex_t* reg;
   OnigErrorInfo einfo;

--- a/test/testu.c
+++ b/test/testu.c
@@ -14,6 +14,10 @@ static int nsucc  = 0;
 static int nfail  = 0;
 static int nerror = 0;
 
+#ifdef __TRUSTINSOFT_ANALYZER__
+static int nall = 0;
+#endif
+
 static FILE* err_file;
 
 #ifndef POSIX_TEST
@@ -25,6 +29,10 @@ static OnigEncoding ENC;
 
 static void uconv(char* from, char* to, int len)
 {
+#ifdef __TRUSTINSOFT_ANALYZER__
+  if (nall++ % TIS_TEST_CHOOSE_MAX != TIS_TEST_CHOOSE_CURRENT) return;
+#endif
+
   int i;
   unsigned char c;
   char *q;

--- a/tis-ci/config.h
+++ b/tis-ci/config.h
@@ -1,0 +1,109 @@
+/* src/config.h.  Generated from config.h.in by configure.  */
+/* src/config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to one of `_getb67', `GETB67', `getb67' for Cray-2 and Cray-YMP
+   systems. This function is required for `alloca.c' support on those systems.
+   */
+/* #undef CRAY_STACKSEG_END */
+
+/* Define to 1 if using `alloca.c'. */
+/* #undef C_ALLOCA */
+
+/* Define to 1 if you have `alloca', as a function or macro. */
+#define HAVE_ALLOCA 1
+
+/* Define to 1 if you have <alloca.h> and it should be used (not on Ultrix).
+   */
+#define HAVE_ALLOCA_H 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/times.h> header file. */
+#define HAVE_SYS_TIMES_H 1
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#define HAVE_SYS_TIME_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Name of package */
+#define PACKAGE "onig"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT ""
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "onig"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "onig 6.9.4"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "onig"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "6.9.4"
+
+/* The size of `int', as computed by sizeof. */
+#define SIZEOF_INT 4
+
+/* The size of `long', as computed by sizeof. */
+#define SIZEOF_LONG 8
+
+/* The size of `long long', as computed by sizeof. */
+#define SIZEOF_LONG_LONG 8
+
+/* The size of `void*', as computed by sizeof. */
+#define SIZEOF_VOIDP 8
+
+/* If using the C implementation of alloca, define if you know the
+   direction of stack growth for your system; otherwise it will be
+   automatically deduced at runtime.
+	STACK_DIRECTION > 0 => grows toward higher addresses
+	STACK_DIRECTION < 0 => grows toward lower addresses
+	STACK_DIRECTION = 0 => direction of growth unknown */
+/* #undef STACK_DIRECTION */
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Define if enable CR+NL as line terminator */
+/* #undef USE_CRNL_AS_LINE_TERMINATOR */
+
+/* Version number of package */
+#define VERSION "6.9.4"
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+/* #undef size_t */

--- a/tis-ci/stub.c
+++ b/tis-ci/stub.c
@@ -1,0 +1,3 @@
+void srand(unsigned int seed) {
+  return;
+}

--- a/tis-ci/test_back.config
+++ b/tis-ci/test_back.config
@@ -1,0 +1,23 @@
+{
+  "compilation_cmd": "-I ../tis-ci -I ../src -D alloca=__builtin_alloca",
+  "files": [
+    "../test/test_back.c",
+    "../src/unicode.c",
+    "../src/regcomp.c",
+    "../src/regenc.c",
+    "../src/utf16_be.c",
+    "../src/regparse.c",
+    "../src/st.c",
+    "../src/regexec.c",
+    "../src/unicode_unfold_key.c",
+    "../src/unicode_fold3_key.c",
+    "../src/unicode_fold2_key.c",
+    "../src/unicode_fold1_key.c",
+    "../src/utf8.c",
+    "../src/regversion.c"
+  ],
+  "machdep": "gcc_x86_64",
+  "main": "main",
+  "name": "test_back.c FULL",
+  "address-alignment": 65536 /* hexadecimal 0x10000 */
+}

--- a/tis-ci/test_regset.config
+++ b/tis-ci/test_regset.config
@@ -1,0 +1,19 @@
+{
+  "compilation_cmd": "-I ../tis-ci -I ../src -D alloca=__builtin_alloca",
+  "files": [
+    "../test/test_regset.c",
+    "../tis-ci/stub.c",
+    "../src/regcomp.c",
+    "../src/regenc.c",
+    "../src/utf8.c",
+    "../src/regexec.c",
+    "../src/ascii.c",
+    "../src/regparse.c",
+    "../src/st.c",
+    "../src/regversion.c"
+  ],
+  "machdep": "gcc_x86_64",
+  "main": "main",
+  "name": "test_regset.c FULL",
+  "address-alignment": 65536 /* hexadecimal 0x10000 */
+}

--- a/tis-ci/test_syntax.config
+++ b/tis-ci/test_syntax.config
@@ -1,0 +1,25 @@
+{
+  "compilation_cmd": "-I ../tis-ci -I ../src -D alloca=__builtin_alloca",
+  "files": [
+    "../test/test_syntax.c",
+    "../src/unicode.c",
+    "../src/regcomp.c",
+    "../src/regenc.c",
+    "../src/utf16_be.c",
+    "../src/regparse.c",
+    "../src/st.c",
+    "../src/regexec.c",
+    "../src/unicode_unfold_key.c",
+    "../src/unicode_fold3_key.c",
+    "../src/unicode_fold2_key.c",
+    "../src/unicode_fold1_key.c",
+    "../src/utf8.c",
+    "../src/regsyntax.c",
+    "../src/ascii.c",
+    "../src/regversion.c"
+  ],
+  "machdep": "gcc_x86_64",
+  "main": "main",
+  "name": "test_syntax.c FULL",
+  "address-alignment": 65536 /* hexadecimal 0x10000 */
+}

--- a/tis-ci/test_utf8.config
+++ b/tis-ci/test_utf8.config
@@ -1,0 +1,24 @@
+{
+  "compilation_cmd": "-I ../tis-ci -I ../src -D alloca=__builtin_alloca",
+  "files": [
+    "../test/test_utf8.c",
+    "../tis-ci/stub.c",
+    "../src/regcomp.c",
+    "../src/regenc.c",
+    "../src/utf8.c",
+    "../src/regexec.c",
+    "../src/ascii.c",
+    "../src/regparse.c",
+    "../src/st.c",
+    "../src/unicode.c",
+    "../src/unicode_unfold_key.c",
+    "../src/unicode_fold3_key.c",
+    "../src/unicode_fold2_key.c",
+    "../src/unicode_fold1_key.c",
+    "../src/regversion.c"
+  ],
+  "machdep": "gcc_x86_64",
+  "main": "main",
+  "name": "test_utf8.c FULL",
+  "address-alignment": 65536 /* hexadecimal 0x10000 */
+}

--- a/tis-ci/testc.config
+++ b/tis-ci/testc.config
@@ -1,0 +1,24 @@
+{
+  "compilation_cmd": "-I ../tis-ci -I ../src -D alloca=__builtin_alloca",
+  "files": [
+    "../test/testc.c",
+    "../src/unicode.c",
+    "../src/regcomp.c",
+    "../src/regenc.c",
+    "../src/utf16_be.c",
+    "../src/regparse.c",
+    "../src/st.c",
+    "../src/regexec.c",
+    "../src/unicode_unfold_key.c",
+    "../src/unicode_fold3_key.c",
+    "../src/unicode_fold2_key.c",
+    "../src/unicode_fold1_key.c",
+    "../src/euc_jp.c",
+    "../src/ascii.c",
+    "../src/regversion.c"
+  ],
+  "machdep": "gcc_x86_64",
+  "main": "main",
+  "name": "testc.c FULL",
+  "address-alignment": 65536 /* hexadecimal 0x10000 */
+}

--- a/tis-ci/testu.config
+++ b/tis-ci/testu.config
@@ -1,0 +1,23 @@
+{
+  "compilation_cmd": "-I ../tis-ci -I ../src -D alloca=__builtin_alloca",
+  "files": [
+    "../test/testu.c",
+    "../src/unicode.c",
+    "../src/regcomp.c",
+    "../src/regenc.c",
+    "../src/utf16_be.c",
+    "../src/regparse.c",
+    "../src/st.c",
+    "../src/regexec.c",
+    "../src/unicode_unfold_key.c",
+    "../src/unicode_fold3_key.c",
+    "../src/unicode_fold2_key.c",
+    "../src/unicode_fold1_key.c",
+    "../src/utf8.c",
+    "../src/regversion.c"
+  ],
+  "machdep": "gcc_x86_64",
+  "main": "main",
+  "name": "testu.c FULL",
+  "address-alignment": 65536 /* hexadecimal 0x10000 */
+}

--- a/tis.config
+++ b/tis.config
@@ -1,0 +1,1336 @@
+[
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=1",
+    "name": "test_utf8.c (1/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=2",
+    "name": "test_utf8.c (2/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=3",
+    "name": "test_utf8.c (3/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=4",
+    "name": "test_utf8.c (4/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=5",
+    "name": "test_utf8.c (5/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=6",
+    "name": "test_utf8.c (6/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=7",
+    "name": "test_utf8.c (7/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=8",
+    "name": "test_utf8.c (8/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=9",
+    "name": "test_utf8.c (9/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=10",
+    "name": "test_utf8.c (10/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=11",
+    "name": "test_utf8.c (11/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=12",
+    "name": "test_utf8.c (12/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=13",
+    "name": "test_utf8.c (13/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=14",
+    "name": "test_utf8.c (14/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=15",
+    "name": "test_utf8.c (15/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=16",
+    "name": "test_utf8.c (16/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=17",
+    "name": "test_utf8.c (17/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=18",
+    "name": "test_utf8.c (18/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=19",
+    "name": "test_utf8.c (19/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=20",
+    "name": "test_utf8.c (20/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=21",
+    "name": "test_utf8.c (21/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=22",
+    "name": "test_utf8.c (22/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=23",
+    "name": "test_utf8.c (23/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=24",
+    "name": "test_utf8.c (24/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=25",
+    "name": "test_utf8.c (25/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=26",
+    "name": "test_utf8.c (26/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=27",
+    "name": "test_utf8.c (27/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=28",
+    "name": "test_utf8.c (28/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=29",
+    "name": "test_utf8.c (29/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=30",
+    "name": "test_utf8.c (30/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=31",
+    "name": "test_utf8.c (31/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=32",
+    "name": "test_utf8.c (32/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=33",
+    "name": "test_utf8.c (33/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=34",
+    "name": "test_utf8.c (34/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=35",
+    "name": "test_utf8.c (35/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=36",
+    "name": "test_utf8.c (36/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=37",
+    "name": "test_utf8.c (37/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=38",
+    "name": "test_utf8.c (38/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=39",
+    "name": "test_utf8.c (39/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=40",
+    "name": "test_utf8.c (40/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=41",
+    "name": "test_utf8.c (41/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=42",
+    "name": "test_utf8.c (42/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=43",
+    "name": "test_utf8.c (43/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=44",
+    "name": "test_utf8.c (44/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=45",
+    "name": "test_utf8.c (45/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=46",
+    "name": "test_utf8.c (46/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=47",
+    "name": "test_utf8.c (47/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=48",
+    "name": "test_utf8.c (48/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=49",
+    "name": "test_utf8.c (49/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=50",
+    "name": "test_utf8.c (50/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=51",
+    "name": "test_utf8.c (51/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=52",
+    "name": "test_utf8.c (52/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=53",
+    "name": "test_utf8.c (53/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=54",
+    "name": "test_utf8.c (54/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=55",
+    "name": "test_utf8.c (55/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=56",
+    "name": "test_utf8.c (56/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=57",
+    "name": "test_utf8.c (57/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=58",
+    "name": "test_utf8.c (58/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=59",
+    "name": "test_utf8.c (59/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=60",
+    "name": "test_utf8.c (60/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=61",
+    "name": "test_utf8.c (61/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=62",
+    "name": "test_utf8.c (62/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=63",
+    "name": "test_utf8.c (63/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=64",
+    "name": "test_utf8.c (64/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=65",
+    "name": "test_utf8.c (65/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=66",
+    "name": "test_utf8.c (66/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=67",
+    "name": "test_utf8.c (67/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=68",
+    "name": "test_utf8.c (68/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=69",
+    "name": "test_utf8.c (69/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=70",
+    "name": "test_utf8.c (70/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=71",
+    "name": "test_utf8.c (71/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=72",
+    "name": "test_utf8.c (72/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=73",
+    "name": "test_utf8.c (73/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=74",
+    "name": "test_utf8.c (74/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=75",
+    "name": "test_utf8.c (75/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=76",
+    "name": "test_utf8.c (76/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=77",
+    "name": "test_utf8.c (77/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=78",
+    "name": "test_utf8.c (78/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=79",
+    "name": "test_utf8.c (79/80)"
+  },
+  {
+    "include": "tis-ci/test_utf8.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=0",
+    "name": "test_utf8.c (80/80)"
+  },
+  {
+    "include": "tis-ci/test_regset.config",
+    "name": "test_regset.c FULL"
+  },
+  {
+    "include": "tis-ci/test_syntax.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=6 -DTIS_TEST_CHOOSE_CURRENT=1",
+    "name": "test_syntax.c (1/6)"
+  },
+  {
+    "include": "tis-ci/test_syntax.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=6 -DTIS_TEST_CHOOSE_CURRENT=2",
+    "name": "test_syntax.c (2/6)"
+  },
+  {
+    "include": "tis-ci/test_syntax.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=6 -DTIS_TEST_CHOOSE_CURRENT=3",
+    "name": "test_syntax.c (3/6)"
+  },
+  {
+    "include": "tis-ci/test_syntax.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=6 -DTIS_TEST_CHOOSE_CURRENT=4",
+    "name": "test_syntax.c (4/6)"
+  },
+  {
+    "include": "tis-ci/test_syntax.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=6 -DTIS_TEST_CHOOSE_CURRENT=5",
+    "name": "test_syntax.c (5/6)"
+  },
+  {
+    "include": "tis-ci/test_syntax.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=6 -DTIS_TEST_CHOOSE_CURRENT=0",
+    "name": "test_syntax.c (6/6)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=1",
+    "name": "testu.c (1/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=2",
+    "name": "testu.c (2/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=3",
+    "name": "testu.c (3/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=4",
+    "name": "testu.c (4/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=5",
+    "name": "testu.c (5/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=6",
+    "name": "testu.c (6/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=7",
+    "name": "testu.c (7/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=8",
+    "name": "testu.c (8/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=9",
+    "name": "testu.c (9/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=10",
+    "name": "testu.c (10/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=11",
+    "name": "testu.c (11/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=12",
+    "name": "testu.c (12/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=13",
+    "name": "testu.c (13/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=14",
+    "name": "testu.c (14/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=15",
+    "name": "testu.c (15/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=16",
+    "name": "testu.c (16/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=17",
+    "name": "testu.c (17/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=18",
+    "name": "testu.c (18/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=19",
+    "name": "testu.c (19/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=20",
+    "name": "testu.c (20/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=21",
+    "name": "testu.c (21/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=22",
+    "name": "testu.c (22/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=23",
+    "name": "testu.c (23/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=24",
+    "name": "testu.c (24/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=25",
+    "name": "testu.c (25/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=26",
+    "name": "testu.c (26/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=27",
+    "name": "testu.c (27/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=28",
+    "name": "testu.c (28/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=29",
+    "name": "testu.c (29/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=30",
+    "name": "testu.c (30/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=31",
+    "name": "testu.c (31/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=32",
+    "name": "testu.c (32/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=33",
+    "name": "testu.c (33/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=34",
+    "name": "testu.c (34/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=35",
+    "name": "testu.c (35/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=36",
+    "name": "testu.c (36/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=37",
+    "name": "testu.c (37/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=38",
+    "name": "testu.c (38/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=39",
+    "name": "testu.c (39/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=40",
+    "name": "testu.c (40/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=41",
+    "name": "testu.c (41/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=42",
+    "name": "testu.c (42/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=43",
+    "name": "testu.c (43/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=44",
+    "name": "testu.c (44/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=45",
+    "name": "testu.c (45/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=46",
+    "name": "testu.c (46/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=47",
+    "name": "testu.c (47/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=48",
+    "name": "testu.c (48/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=49",
+    "name": "testu.c (49/50)"
+  },
+  {
+    "include": "tis-ci/testu.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=0",
+    "name": "testu.c (50/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=1",
+    "name": "testc.c (1/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=2",
+    "name": "testc.c (2/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=3",
+    "name": "testc.c (3/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=4",
+    "name": "testc.c (4/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=5",
+    "name": "testc.c (5/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=6",
+    "name": "testc.c (6/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=7",
+    "name": "testc.c (7/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=8",
+    "name": "testc.c (8/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=9",
+    "name": "testc.c (9/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=10",
+    "name": "testc.c (10/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=11",
+    "name": "testc.c (11/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=12",
+    "name": "testc.c (12/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=13",
+    "name": "testc.c (13/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=14",
+    "name": "testc.c (14/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=15",
+    "name": "testc.c (15/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=16",
+    "name": "testc.c (16/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=17",
+    "name": "testc.c (17/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=18",
+    "name": "testc.c (18/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=19",
+    "name": "testc.c (19/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=20",
+    "name": "testc.c (20/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=21",
+    "name": "testc.c (21/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=22",
+    "name": "testc.c (22/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=23",
+    "name": "testc.c (23/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=24",
+    "name": "testc.c (24/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=25",
+    "name": "testc.c (25/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=26",
+    "name": "testc.c (26/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=27",
+    "name": "testc.c (27/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=28",
+    "name": "testc.c (28/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=29",
+    "name": "testc.c (29/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=30",
+    "name": "testc.c (30/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=31",
+    "name": "testc.c (31/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=32",
+    "name": "testc.c (32/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=33",
+    "name": "testc.c (33/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=34",
+    "name": "testc.c (34/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=35",
+    "name": "testc.c (35/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=36",
+    "name": "testc.c (36/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=37",
+    "name": "testc.c (37/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=38",
+    "name": "testc.c (38/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=39",
+    "name": "testc.c (39/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=40",
+    "name": "testc.c (40/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=41",
+    "name": "testc.c (41/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=42",
+    "name": "testc.c (42/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=43",
+    "name": "testc.c (43/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=44",
+    "name": "testc.c (44/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=45",
+    "name": "testc.c (45/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=46",
+    "name": "testc.c (46/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=47",
+    "name": "testc.c (47/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=48",
+    "name": "testc.c (48/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=49",
+    "name": "testc.c (49/50)"
+  },
+  {
+    "include": "tis-ci/testc.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=50 -DTIS_TEST_CHOOSE_CURRENT=0",
+    "name": "testc.c (50/50)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=1",
+    "name": "test_back.c (1/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=2",
+    "name": "test_back.c (2/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=3",
+    "name": "test_back.c (3/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=4",
+    "name": "test_back.c (4/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=5",
+    "name": "test_back.c (5/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=6",
+    "name": "test_back.c (6/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=7",
+    "name": "test_back.c (7/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=8",
+    "name": "test_back.c (8/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=9",
+    "name": "test_back.c (9/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=10",
+    "name": "test_back.c (10/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=11",
+    "name": "test_back.c (11/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=12",
+    "name": "test_back.c (12/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=13",
+    "name": "test_back.c (13/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=14",
+    "name": "test_back.c (14/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=15",
+    "name": "test_back.c (15/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=16",
+    "name": "test_back.c (16/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=17",
+    "name": "test_back.c (17/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=18",
+    "name": "test_back.c (18/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=19",
+    "name": "test_back.c (19/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=20",
+    "name": "test_back.c (20/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=21",
+    "name": "test_back.c (21/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=22",
+    "name": "test_back.c (22/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=23",
+    "name": "test_back.c (23/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=24",
+    "name": "test_back.c (24/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=25",
+    "name": "test_back.c (25/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=26",
+    "name": "test_back.c (26/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=27",
+    "name": "test_back.c (27/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=28",
+    "name": "test_back.c (28/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=29",
+    "name": "test_back.c (29/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=30",
+    "name": "test_back.c (30/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=31",
+    "name": "test_back.c (31/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=32",
+    "name": "test_back.c (32/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=33",
+    "name": "test_back.c (33/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=34",
+    "name": "test_back.c (34/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=35",
+    "name": "test_back.c (35/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=36",
+    "name": "test_back.c (36/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=37",
+    "name": "test_back.c (37/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=38",
+    "name": "test_back.c (38/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=39",
+    "name": "test_back.c (39/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=40",
+    "name": "test_back.c (40/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=41",
+    "name": "test_back.c (41/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=42",
+    "name": "test_back.c (42/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=43",
+    "name": "test_back.c (43/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=44",
+    "name": "test_back.c (44/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=45",
+    "name": "test_back.c (45/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=46",
+    "name": "test_back.c (46/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=47",
+    "name": "test_back.c (47/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=48",
+    "name": "test_back.c (48/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=49",
+    "name": "test_back.c (49/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=50",
+    "name": "test_back.c (50/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=51",
+    "name": "test_back.c (51/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=52",
+    "name": "test_back.c (52/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=53",
+    "name": "test_back.c (53/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=54",
+    "name": "test_back.c (54/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=55",
+    "name": "test_back.c (55/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=56",
+    "name": "test_back.c (56/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=57",
+    "name": "test_back.c (57/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=58",
+    "name": "test_back.c (58/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=59",
+    "name": "test_back.c (59/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=60",
+    "name": "test_back.c (60/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=61",
+    "name": "test_back.c (61/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=62",
+    "name": "test_back.c (62/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=63",
+    "name": "test_back.c (63/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=64",
+    "name": "test_back.c (64/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=65",
+    "name": "test_back.c (65/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=66",
+    "name": "test_back.c (66/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=67",
+    "name": "test_back.c (67/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=68",
+    "name": "test_back.c (68/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=69",
+    "name": "test_back.c (69/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=70",
+    "name": "test_back.c (70/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=71",
+    "name": "test_back.c (71/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=72",
+    "name": "test_back.c (72/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=73",
+    "name": "test_back.c (73/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=74",
+    "name": "test_back.c (74/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=75",
+    "name": "test_back.c (75/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=76",
+    "name": "test_back.c (76/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=77",
+    "name": "test_back.c (77/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=78",
+    "name": "test_back.c (78/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=79",
+    "name": "test_back.c (79/80)"
+  },
+  {
+    "include": "tis-ci/test_back.config",
+    "compilation_cmd": "-DTIS_TEST_CHOOSE_MAX=80 -DTIS_TEST_CHOOSE_CURRENT=0",
+    "name": "test_back.c (80/80)"
+  }
+]


### PR DESCRIPTION
Following up with [https://github.com/kkos/oniguruma/issues/208](https://github.com/kkos/oniguruma/issues/208), here is a Pull Request with the TIS CI configuration.

For you to make the most of TIS CI, I have split 6 of the oniguruma's large tests - `test_utf8.c`, `test_regset.c`, `test_syntax.c`, `testu.c`, `testc.c`, `test_back.c` - into 267 smaller TIS CI tests (for example, `test_utf8.c` has been split into 80 TIS CI tests):  
[https://ci.trust-in-soft.com/projects/jakub-zwolakowski/oniguruma/14](https://ci.trust-in-soft.com/projects/jakub-zwolakowski/oniguruma/14)

Each TIS CI test is now small enough that it can be "explored" in case an issue has been detected in the code, via the **Explore** button. This helps a lot in pinpointing the problems and understanding where they come from.

About the files that are part of this PR:

*   `tis.config`:  
    The main configuration file that describes the 267 execution paths to analyze (i.e. the TIS-CI tests). Each entry in this JSON corresponds to one TIS CI test.  
    (For more information on configuration files: [https://docs.ci.trust-in-soft.com/reference/configuration-file](https://docs.ci.trust-in-soft.com/reference/configuration-file))
*   `tis-ci/test_*.config`:  
    Each of these configuration files contains the analysis options specific to one of the 6 oniguruma's tests, such as the list of source files to analyze. These files are used multiple times in the main `tis.config` file via the option `"include"`.
*   `test/test*.c`:  
    The test files themselves have been modified to enable splitting of the oniguruma's test suite into smaller TIS CI tests.  
    This split is based on the fact that every large oniguruma test is made of a number of unitary sub-cases, which all end up calling the same function `xx`. Each TIS CI test is configured in the `tis.config` file to include a subset of all the sub-cases by selecting only certain calls to `xx`.
*   `tis-ci/config.h`:  
    A copy of the generated header `src/config.h` (TIS CI needs this header to perform the analysis, but it is not able to build projects right now, so all such files must be included explicitly).
*   `tis-ci/stub.c`:  
    Contains function stubs and other bits necessary for the analysis. In this case only the function `srand` must be defined (TIS CI needs the analysis to be deterministic, so functions related with randomness must be stubbed).
*   Finally, the TIS CI badge was added to `[README.md](http://README.md)`. It shows the verification status for the last commit on the **master** branch. If you want something else (e.g. last commit on any branch) you'd have to modify it.  
    (For more information see: [https://docs.ci.trust-in-soft.com/reference/status-badge](https://docs.ci.trust-in-soft.com/reference/status-badge))

After merging this PR, you only need to add the repo to TIS CI from your side. The tutorial is available ([https://docs.ci.trust-in-soft.com/tutorial/set-up-the-continuous-verification#trigger-the-first-analysis](https://docs.ci.trust-in-soft.com/tutorial/set-up-the-continuous-verification#trigger-the-first-analysis)), but it boils down to these steps:
1.  Go to [https://ci.trust-in-soft.com/](https://ci.trust-in-soft.com/) and sign up,
2.  Once on TIS-CI, click on **Add Project** (in the top navigation menu),
3.  Choose **oniguruma** from the project list,
4.  Choose the **branch** where this PR was merged (the one with the `tis.config` file),
5.  Click on **Start verifying**.

And you should be all good! The final effect shoul look similar to this:  
[https://ci.trust-in-soft.com/projects/jakub-zwolakowski/oniguruma/14](https://ci.trust-in-soft.com/projects/jakub-zwolakowski/oniguruma/14)

From this point forward all pushes to the repo will automatically trigger a new TIS-CI verification on all the branches which contain a `tis.config` file at the repository root.