### PR TITLE
UB#12 fix / workaround

### DIFF
--- a/src/regexec.c
+++ b/src/regexec.c
@@ -1060,6 +1060,9 @@ onig_region_copy(OnigRegion* to, OnigRegion* from)
 
 
 /** stack **/
+static char TIS_INVALID_STACK;
+#define INVALID_STACK_INDEX   ((intptr_t)(&TIS_INVALID_STACK))
+
 #define STK_ALT_FLAG               0x0001
 
 /* stack type */
@@ -1101,8 +1104,6 @@ onig_region_copy(OnigRegion* to, OnigRegion* from)
 #define STK_MASK_MEM_END_OR_MARK   0x8000  /* MEM_END or MEM_END_MARK */
 
 typedef ssize_t StackIndex;
-
-#define INVALID_STACK_INDEX   ((StackIndex )-1)
 
 typedef union {
   StackIndex i;

--- a/tis-ci/test_back.config
+++ b/tis-ci/test_back.config
@@ -19,5 +19,6 @@
   "machdep": "gcc_x86_64",
   "main": "main",
   "name": "test_back.c FULL",
-  "address-alignment": 65536 /* hexadecimal 0x10000 */
+  "address-alignment": 65536 /* hexadecimal 0x10000 */,
+  "val-warn-undefined-pointer-comparison": "none"
 }

--- a/tis-ci/test_regset.config
+++ b/tis-ci/test_regset.config
@@ -15,5 +15,6 @@
   "machdep": "gcc_x86_64",
   "main": "main",
   "name": "test_regset.c FULL",
-  "address-alignment": 65536 /* hexadecimal 0x10000 */
+  "address-alignment": 65536 /* hexadecimal 0x10000 */,
+  "val-warn-undefined-pointer-comparison": "none"
 }

--- a/tis-ci/test_syntax.config
+++ b/tis-ci/test_syntax.config
@@ -21,5 +21,6 @@
   "machdep": "gcc_x86_64",
   "main": "main",
   "name": "test_syntax.c FULL",
-  "address-alignment": 65536 /* hexadecimal 0x10000 */
+  "address-alignment": 65536 /* hexadecimal 0x10000 */,
+  "val-warn-undefined-pointer-comparison": "none"
 }

--- a/tis-ci/test_utf8.config
+++ b/tis-ci/test_utf8.config
@@ -20,5 +20,6 @@
   "machdep": "gcc_x86_64",
   "main": "main",
   "name": "test_utf8.c FULL",
-  "address-alignment": 65536 /* hexadecimal 0x10000 */
+  "address-alignment": 65536 /* hexadecimal 0x10000 */,
+  "val-warn-undefined-pointer-comparison": "none"
 }

--- a/tis-ci/testc.config
+++ b/tis-ci/testc.config
@@ -20,5 +20,6 @@
   "machdep": "gcc_x86_64",
   "main": "main",
   "name": "testc.c FULL",
-  "address-alignment": 65536 /* hexadecimal 0x10000 */
+  "address-alignment": 65536 /* hexadecimal 0x10000 */,
+  "val-warn-undefined-pointer-comparison": "none"
 }

--- a/tis-ci/testu.config
+++ b/tis-ci/testu.config
@@ -19,5 +19,6 @@
   "machdep": "gcc_x86_64",
   "main": "main",
   "name": "testu.c FULL",
-  "address-alignment": 65536 /* hexadecimal 0x10000 */
+  "address-alignment": 65536 /* hexadecimal 0x10000 */,
+  "val-warn-undefined-pointer-comparison": "none"
 }


### PR DESCRIPTION
Hi @kkos !

I'm making this PR directly as an answer to your comment: https://github.com/kkos/oniguruma/issues/208#issuecomment-703346577

Nice to see that you have been playing with TIS CI and trying to correct the UBs :slightly_smiling_face:  
I appreciate your feedback a lot! Let me help you with getting ahead of these issues you've encountered.

### UB#3 again

First off, I see that by trying to fix the next problem, you actually undid the fix for **UB#3** with this commit: [https://github.com/kkos/oniguruma/commit/bee078ee6e373351eaa0cdbdc71bb13b22f9952d](https://github.com/kkos/oniguruma/commit/bee078ee6e373351eaa0cdbdc71bb13b22f9952d)

That's why you have **UB#3** coming back for the first two test cases. You can see it here:

*   **Before** pushing this commit the first two tests are green: [https://ci.trust-in-soft.com/projects/kkos/oniguruma/1?test=1,2](https://ci.trust-in-soft.com/projects/kkos/oniguruma/1?test=1,2)  
    ![oniguruma before undoing UB#3 fix](https://user-images.githubusercontent.com/1905935/95099758-9c7a0880-0730-11eb-9f29-622007891a18.png)
*   **After** pushing this commit they go red again: [https://ci.trust-in-soft.com/projects/kkos/oniguruma/2?test=1,2](https://ci.trust-in-soft.com/projects/kkos/oniguruma/2?test=1,2)  
    ![oniguruma after undoing UB#3 fix](https://user-images.githubusercontent.com/1905935/95099800-a865ca80-0730-11eb-961b-945c69a8db8d.png)

So I believe that this fix was good and it did solve this particular problem. Thus that would be the first thing that I'd suggest fixing again.

### UB#12

Now, there is another separate problem to solve, let's call it **UB#12** (it was already mentioned in the list here: [https://github.com/kkos/oniguruma/issues/206](https://github.com/kkos/oniguruma/issues/206)).

**UB#12** appears in many test cases, for example here: [https://ci.trust-in-soft.com/projects/kkos/oniguruma/1?page=1&test=3](https://ci.trust-in-soft.com/projects/kkos/oniguruma/1?page=1&test=3), with description **"Invalid pointer comparison in function 'match\_at' in file 'src/regexec.c' line 3733."**

![oniguruma UB#12 in test case 3](https://user-images.githubusercontent.com/1905935/95099979-e4009480-0730-11eb-874b-ce57fe1228e3.png)

I think I know what is going on. But I don't know how to fix it, it's too complex for me... However, I can propose you a workaround.

But before doing that I'd like to show you how you can use **Explore** to understand what is actually going on. And then you can decide if you prefer to find a proper fix or use the workaround.

### Exploring UB#12

The original line of code where the problem occurs is [this one](https://github.com/kkos/oniguruma/blob/8155473a2ab783b91e9f5a2e308bb7b5c4fec344/src/regexec.c#L3733):  
`if (mem_end_stk[mem] == INVALID_STACK_INDEX) goto fail;`

TIS CI normalizes the code by expanding the macros, unraveling the side effects, etc, and in case of encountering an UB it inserts annotations concerning code properties. So what you see in the interactive code pane (middle pane) looks like this:

![oniguruma UB#12 interactive code](https://user-images.githubusercontent.com/1905935/95099920-d0edc480-0730-11eb-8e5c-1625a3b061b2.png)

Now you can make TIS CI show you the values of all the variables that are present at this program point (and what the pointers are pointing to) in order to understand which pointer comparison is causing the alarm.

This is the memory state of all the relevant variables at this point ([see the video how to get there with TIS CI **Explore**](https://youtu.be/uiGgJElj6mg)):

![oniguruma UB#12 values of variables marked](https://user-images.githubusercontent.com/1905935/95100268-39d53c80-0731-11eb-93d5-13fcace0f219.png)

*   `TIS_INVALID_STACK` is equal 0 and `&TIS_INVALID_STACK` (in the original code it's the macro `INVALID_STACK_INDEX`) is pointing at it. Seems OK.
*   `mem_end_stk` points at the cell 16 of a dynamically allocated buffer of memory called here `__malloc_match_at_l2950_13`. (TIS CI gives unique names such as this one to all allocated blocks of memory in order to distinguish between them).
*   `mem` is equal 1.
*   So the expression `mem_end_stk + mem` points at the cell 24 of this allocated buffer.
*   And the value at this address (i.e. the value of the expression `*(mem_end_stk + mem)`) is 5.
*   We can also look into the whole contents of `__malloc_match_at_l2950_13` and see that it contains a mix of different things, some addresses (e.g. `&TIS_INVALID_STACK` appears there too), and effectively what would be cell 24 (bits 192 to 255) there is just value 5 stored.

Hence ultimately the comparison we make is indeed between a value `5` and an address `&TIS INVALID STACK`. This does not necessarily correspond to run-time error, but relying on an Undefined Behavior of the compiler is generally undesirable.

### Solutions for UB#12

Now about fixing this situation. This seems to be much deeper than the other UBs I've discovered before... I have no idea how to avoid making such comparisons in the code here, it seems to require a non-local solution, so I don't have any fix for you... I have a workaround though.

So there are basically two ways out of this:

*   You may decide to consider this UB as a **serious problem** and you may investigate further and find a way to fix it.
*   Or you may decide that this is **not a serious problem** and tell TIS CI to ignore it.  
    There exists an option "val-warn-undefined-pointer-comparison" that can be used, so that TIS CI stops emitting alarms for this kind of UBs. This basically reduces the analysis perimeter: you tell TIS CI to give you less guarantees about your the code (i.e. do not guarantee that all pointer comparisons are valid), but it lets you ignore this particular UB. So that's fine if you feel that this UB is not dangerous or important.

This PR implements the second option (ignoring the UB), so you can see how it looks like. It includes fixing UB#3 again.

You may accept it or not, depending on how you feel about the importance of this UB and the level of guarantees you need.