### PR TITLE
Fix the misplaced #ifdef in initial TIS CI config

### DIFF
--- a/test/testu.c
+++ b/test/testu.c
@@ -29,10 +29,6 @@ static OnigEncoding ENC;
 
 static void uconv(char* from, char* to, int len)
 {
-#ifdef __TRUSTINSOFT_ANALYZER__
-  if (nall++ % TIS_TEST_CHOOSE_MAX != TIS_TEST_CHOOSE_CURRENT) return;
-#endif
-
   int i;
   unsigned char c;
   char *q;
@@ -66,6 +62,10 @@ static void uconv(char* from, char* to, int len)
 
 static void xx(char* pattern, char* str, int from, int to, int mem, int not)
 {
+#ifdef __TRUSTINSOFT_ANALYZER__
+  if (nall++ % TIS_TEST_CHOOSE_MAX != TIS_TEST_CHOOSE_CURRENT) return;
+#endif
+
   int r;
   char cpat[4000], cstr[4000];
 


### PR DESCRIPTION
This PR is just to correct a mistake in the initial TIS CI configuration on my part.  

Sorry!... I've realized that something was wrong when I looked closer on my oniguruma verifications in TIS CI. Indeed, I've put the `#ifdef` directive in the wrong function in `testu.c` which causes problems with all the tests based on this file.

With this little patch this should be good!

(This has nothing to do with correcting the UBs, completely orthogonal topic.)