### PR TITLE
fix TIS-CI config: add src/ascii.c to tis-ci/test_back.config files

### DIFF
--- a/tis-ci/test_back.config
+++ b/tis-ci/test_back.config
@@ -15,7 +15,8 @@
     "../src/unicode_fold1_key.c",
     "../src/utf8.c",
     "../src/regerror.c",
-    "../src/regversion.c"
+    "../src/regversion.c",
+    "../src/ascii.c"
   ],
   "machdep": "gcc_x86_64",
   "main": "main",


### PR DESCRIPTION
I've noticed the last UB that you've uncovered and actually I've seen this before... This is a problem with TIS CI, the UB is misdiagnosed here, in reality this is a configuration error. The file defining the `OnigEncodingASCII` global (`src/ascii.c`) is not included in the configuration, so TIS CI has only the declaration to work with, and instead of complaining it goes through with the analysis.

Sorry! I'll report this as an issue internally.

This PR just adds the missing file.