### PR TITLE
docs: fix simple typo, hostory -> history

### DIFF
--- a/sample/listcap.c
+++ b/sample/listcap.c
@@ -103,7 +103,7 @@ extern int main(int argc, char* argv[])
   use_encs[0] = ONIG_ENCODING_ASCII;
   onig_initialize(use_encs, sizeof(use_encs)/sizeof(use_encs[0]));
 
- /* enable capture hostory */
+ /* enable capture history */
   onig_copy_syntax(&syn, ONIG_SYNTAX_DEFAULT);
   onig_set_syntax_op2(&syn,
        onig_get_syntax_op2(&syn) | ONIG_SYN_OP2_ATMARK_CAPTURE_HISTORY);


### PR DESCRIPTION
There is a small typo in sample/listcap.c.

Should read `history` rather than `hostory`.

