### PR TITLE
replace inline with __inline when building with old MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,12 @@ if(MSVC)
 	  $<$<CONFIG:RelWithDebgInfo>:/MTd>
 	  )
   endif()
+  if(MSVC_VERSION LESS_EQUAL "1600")
+    # <= VS2010
+    target_compile_definitions(onig PRIVATE
+      -Dinline=__inline
+      )
+  endif()
 elseif(CMAKE_COMPILER_IS_GNUCC)
   target_compile_options(onig PRIVATE
 	-Wall


### PR DESCRIPTION
Old Visual Studio can't use inline but __inline.
