### PR TITLE
add *.trs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Makefile.in
 *.la
 *.pc
 *.log
+*.trs
 *.dll
 *.lib
 *.exe


### PR DESCRIPTION
The files `*.trs` (Test ReSults) are generated files of `autoconf`. They are created by `make check` with `*.log`. I think we should prevent adding the test result files to git repository.