### PR TITLE
Make sure oniguruma.pc is removed on distclean

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,7 @@ oniguruma.pc: $(srcdir)/oniguruma.pc.in Makefile
 
 pkgconfigdir   = $(libdir)/pkgconfig
 pkgconfig_DATA = oniguruma.pc
-
+DISTCLEANFILES = oniguruma.pc
 
 all-test:
 	cd test; make test


### PR DESCRIPTION
Currently, `oniguruma.pc` is not removed on `make distclean`, so `make distcheck` fails. As a user of oniguruma as a submodule, we're affected by this issue and `make distcheck` on our directory fails due to the uncleaned `oniguruma.pc`. This PR fixes the problem.