### PR TITLE
Update base.c: Add missing int types to calc_retry_limit

### DIFF
--- a/harnesses/base.c
+++ b/harnesses/base.c
@@ -201,7 +201,7 @@ each_match_callback_func(const UChar* str, const UChar* end,
   return ONIG_NORMAL;
 }
 
-static unsigned int calc_retry_limit(sl, len)
+static unsigned int calc_retry_limit(int sl, int len)
 {
   unsigned int r;
   unsigned int upper;


### PR DESCRIPTION
Fixes a clang-18 error:

```
+ clang -O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=address -fsanitize-address-use-after-scope -fsanitize=fuzzer-no-link -o harnesses/fuzzer_syntax.o -I src -c -DSYNTAX_TEST harnesses/base.c
harnesses/base.c:204:42: error: parameter 'len' was not declared, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
  204 | static unsigned int calc_retry_limit(sl, len)
      |                                          ^
  205 | {
harnesses/base.c:204:38: error: parameter 'sl' was not declared, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
  204 | static unsigned int calc_retry_limit(sl, len)
      |                                      ^
  205 | {
harnesses/base.c:204:21: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C23 [-Wdeprecated-non-prototype]
  204 | static unsigned int calc_retry_limit(sl, len)
      |                     ^
1 warning and 2 errors generated.
ERROR:__main__:Building fuzzers failed.
