### PR TITLE
Fix Solaris GCC 14 build.

### DIFF
--- a/src/regint.h
+++ b/src/regint.h
@@ -120,7 +120,7 @@
 #include <stdint.h>
 #endif
 
-#if defined(HAVE_ALLOCA_H) && !defined(__GNUC__)
+#if defined(HAVE_ALLOCA_H)
 #include <alloca.h>
 #endif
 


### PR DESCRIPTION
Build on Solaris fails with:
 src/regint.h:263:18: error: implicit declaration of function ‘alloca’ [-Wimplicit-function-declaration]