### PR TITLE
Mark onig_snprintf_with_pattern() as printf()-like

### DIFF
--- a/src/regint.h
+++ b/src/regint.h
@@ -61,6 +61,14 @@
 #endif
 #endif
 
+#ifndef ONIG_PRINTFLIKE
+#if defined(__clang__) || defined(__GNUC__)
+#define ONIG_PRINTFLIKE(x, y) __attribute__((format(printf, x, y)))
+#else
+#define ONIG_PRINTFLIKE(x, y)
+#endif
+#endif
+
 /* config */
 /* spec. config */
 #define USE_REGSET
@@ -945,7 +953,7 @@ struct re_pattern_buffer {
 extern void onig_add_end_call(void (*func)(void));
 extern void onig_warning(const char* s);
 extern UChar* onig_error_code_to_format P_((int code));
-extern void ONIG_VARIADIC_FUNC_ATTR onig_snprintf_with_pattern PV_((UChar buf[], int bufsize, OnigEncoding enc, UChar* pat, UChar* pat_end, const UChar *fmt, ...));
+extern void ONIG_VARIADIC_FUNC_ATTR ONIG_PRINTFLIKE(6, 7) onig_snprintf_with_pattern PV_((UChar buf[], int bufsize, OnigEncoding enc, UChar* pat, UChar* pat_end, const UChar *fmt, ...));
 extern int onig_compile P_((regex_t* reg, const UChar* pattern, const UChar* pattern_end, OnigErrorInfo* einfo));
 extern int onig_is_code_in_cc_len P_((int enclen, OnigCodePoint code, void* /* CClassNode* */ cc));
 extern RegexExt* onig_get_regex_ext(regex_t* reg);


### PR DESCRIPTION
Without this patch, trying to build Oniguruma with `-Werror=format-nonliteral` (which is the default in some environments, e.g. Xcode) results in the following:

```
regerror.c:363:40: error: format string is not a string literal [-Werror,-Wformat-nonliteral]
  363 |   n = xvsnprintf((char* )buf, bufsize, (const char* )fmt, args);
      |                                        ^             ~~~
1 error generated.
```

By declaring `onig_snprintf_with_pattern()` as `printf()`-like, we tell the compiler to check the format string and arguments at the point where it is called instead.